### PR TITLE
Add subtle star-themed homepage using React Three Fiber

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -14,6 +14,7 @@
         "@cloudflare/vite-plugin": "^1.13.8",
         "@fontsource/poppins": "^5.2.7",
         "@fontsource/zen-kaku-gothic-new": "^5.2.7",
+        "@react-three/fiber": "^9.5.0",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-devtools": "^0.7.0",
         "@tanstack/react-router": "^1.132.0",
@@ -25,6 +26,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "tailwindcss": "^4.1.18",
+        "three": "^0.183.1",
         "vite-tsconfig-paths": "^5.1.4"
     },
     "devDependencies": {

--- a/app/src/routes/-components/star-background/index.tsx
+++ b/app/src/routes/-components/star-background/index.tsx
@@ -1,0 +1,58 @@
+import { Canvas, useFrame } from "@react-three/fiber";
+import { useMemo, useRef } from "react";
+import type { Points } from "three";
+
+function StarPoints() {
+    // 控えめな星空にするため、点の数と範囲を固定して軽量に生成する。
+    const positions = useMemo(() => {
+        const points = new Float32Array(900);
+
+        for (let index = 0; index < points.length; index += 3) {
+            points[index] = (Math.random() - 0.5) * 30;
+            points[index + 1] = (Math.random() - 0.5) * 18;
+            points[index + 2] = (Math.random() - 0.5) * 20;
+        }
+
+        return points;
+    }, []);
+
+    const pointsRef = useRef<Points>(null);
+
+    useFrame((_, delta) => {
+        if (!pointsRef.current) {
+            return;
+        }
+
+        pointsRef.current.rotation.y += delta * 0.02;
+        pointsRef.current.rotation.x += delta * 0.005;
+    });
+
+    return (
+        <points ref={pointsRef}>
+            <bufferGeometry>
+                <bufferAttribute
+                    attach="attributes-position"
+                    count={positions.length / 3}
+                    array={positions}
+                    itemSize={3}
+                />
+            </bufferGeometry>
+            <pointsMaterial color="#dbeafe" size={0.06} sizeAttenuation transparent opacity={0.55} depthWrite={false} />
+        </points>
+    );
+}
+
+export default function StarBackground() {
+    if (typeof window === "undefined") {
+        return null;
+    }
+
+    return (
+        <div className="absolute inset-0 -z-10 pointer-events-none opacity-80">
+            <Canvas camera={{ position: [0, 0, 10], fov: 55 }}>
+                <color attach="background" args={["#020617"]} />
+                <StarPoints />
+            </Canvas>
+        </div>
+    );
+}

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -1,7 +1,43 @@
 import { createFileRoute } from "@tanstack/react-router";
 
+import StarBackground from "./-components/star-background";
+
 export const Route = createFileRoute("/")({ component: App });
 
 function App() {
-    return <div />;
+    return (
+        <main className="relative isolate min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+            <StarBackground />
+
+            <div className="mx-auto flex min-h-screen w-full max-w-5xl flex-col justify-center px-6 py-20">
+                <p className="text-sm tracking-[0.3em] text-blue-200/80">NIKOMARU PORTFOLIO</p>
+                <h1 className="mt-4 max-w-3xl text-4xl font-semibold leading-tight md:text-6xl">
+                    人と体験をやわらかくつなぐ、
+                    <span className="text-blue-200"> Web Creator </span>
+                </h1>
+                <p className="mt-6 max-w-2xl text-base leading-relaxed text-slate-300 md:text-lg">
+                    星をモチーフにしながら、コンテンツを主役にするポートフォリオを目指しました。 React Three Fiber
+                    で控えめな星空を重ねて、静かに印象を残します。
+                </p>
+
+                <div className="mt-10 grid gap-4 md:grid-cols-3">
+                    <article className="rounded-2xl border border-white/10 bg-slate-900/50 p-5 backdrop-blur-sm">
+                        <p className="text-sm text-blue-200">Focus</p>
+                        <h2 className="mt-2 text-lg font-medium">Frontend Engineering</h2>
+                        <p className="mt-2 text-sm text-slate-300">TanStack Start を使った設計と UI 実装。</p>
+                    </article>
+                    <article className="rounded-2xl border border-white/10 bg-slate-900/50 p-5 backdrop-blur-sm">
+                        <p className="text-sm text-blue-200">Skill</p>
+                        <h2 className="mt-2 text-lg font-medium">Creative Coding</h2>
+                        <p className="mt-2 text-sm text-slate-300">軽量な 3D 演出でページに深度を追加します。</p>
+                    </article>
+                    <article className="rounded-2xl border border-white/10 bg-slate-900/50 p-5 backdrop-blur-sm">
+                        <p className="text-sm text-blue-200">Vision</p>
+                        <h2 className="mt-2 text-lg font-medium">Simple & Memorable</h2>
+                        <p className="mt-2 text-sm text-slate-300">主張しすぎず、記憶に残るビジュアルを作ります。</p>
+                    </article>
+                </div>
+            </div>
+        </main>
+    );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@fontsource/zen-kaku-gothic-new':
         specifier: ^5.2.7
         version: 5.2.7
+      '@react-three/fiber':
+        specifier: ^9.5.0
+        version: 9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.183.1)
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
@@ -56,6 +59,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.18
         version: 4.1.18
+      three:
+        specifier: ^0.183.1
+        version: 0.183.1
       vite-tsconfig-paths:
         specifier: ^5.1.4
         version: 5.1.4(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0))
@@ -1132,6 +1138,31 @@ packages:
       '@types/react':
         optional: true
 
+  '@react-three/fiber@9.5.0':
+    resolution: {integrity: sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-beta.40':
     resolution: {integrity: sha512-s3GeJKSQOwBlzdUrj4ISjJj5SfSh+aqn0wjOar4Bx95iV1ETI7F6S/5hLcfAxZ9kXDcyrAkxPlqmd1ZITttf+w==}
 
@@ -1911,6 +1942,11 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
@@ -1925,6 +1961,9 @@ packages:
 
   '@types/wait-on@5.3.4':
     resolution: {integrity: sha512-EBsPjFMrFlMbbUFf9D1Fp+PAB2TwmUn7a3YtHyD9RLuTIk1jDd8SxXVAoez2Ciy+8Jsceo2MYEYZzJ/DvorOKw==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2403,6 +2442,9 @@ packages:
     resolution: {integrity: sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==}
     engines: {node: 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
@@ -2468,6 +2510,9 @@ packages:
 
   buffer-more-ints@0.0.2:
     resolution: {integrity: sha512-PDgX2QJgUc5+Jb2xAoBFP5MxhtVUmZHR33ak+m/SDxRdCrbnX1BggRIaxiW7ImwfmO4iJeCQKN18ToSXWGjYkA==}
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -3435,6 +3480,9 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   import-local@3.2.0:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
@@ -3672,6 +3720,11 @@ packages:
   istanbul-reports@3.2.0:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
+
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
 
   jackspeak@3.4.3:
     resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
@@ -4584,6 +4637,15 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -5023,6 +5085,11 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -5068,6 +5135,9 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  three@0.183.1:
+    resolution: {integrity: sha512-Psv6bbd3d/M/01MT2zZ+VmD0Vj2dbWTNhfe4CuSg7w5TuW96M3NOyCVuh9SZQ05CpGmD7NEcJhZw4GVjhCYxfQ==}
 
   timer2@1.0.0:
     resolution: {integrity: sha512-UOZql+P2ET0da+B7V3/RImN3IhC5ghb+9cpecfUhmYGIm0z73dDr3A781nBLnFYmRzeT1AmoT4w9Lgr8n7n7xg==}
@@ -5695,6 +5765,24 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@5.0.11:
+    resolution: {integrity: sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -6583,6 +6671,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
+  '@react-three/fiber@9.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(three@0.183.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-use-measure: 2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.4)
+      three: 0.183.1
+      use-sync-external-store: 1.6.0(react@19.2.4)
+      zustand: 5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   '@rolldown/pluginutils@1.0.0-beta.40': {}
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
@@ -7433,6 +7541,10 @@ snapshots:
     dependencies:
       '@types/react': 19.2.14
 
+  '@types/react-reconciler@0.28.9(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
@@ -7446,6 +7558,8 @@ snapshots:
   '@types/wait-on@5.3.4':
     dependencies:
       '@types/node': 25.3.0
+
+  '@types/webxr@0.5.24': {}
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -8019,6 +8133,8 @@ snapshots:
 
   balanced-match@4.0.3: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.9.19: {}
 
   basic-auth@2.0.1:
@@ -8092,6 +8208,11 @@ snapshots:
   buffer-from@1.1.2: {}
 
   buffer-more-ints@0.0.2: {}
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -9175,6 +9296,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   import-local@3.2.0:
     dependencies:
       pkg-dir: 4.2.0
@@ -9413,6 +9536,13 @@ snapshots:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+
+  its-fine@2.0.0(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.14)
+      react: 19.2.4
+    transitivePeerDependencies:
+      - '@types/react'
 
   jackspeak@3.4.3:
     dependencies:
@@ -10527,6 +10657,12 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-use-measure@2.1.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
   react@19.2.4: {}
 
   readable-stream@1.1.14:
@@ -11084,6 +11220,10 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  suspend-react@0.1.3(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   symbol-tree@3.2.4: {}
 
   synckit@0.11.12:
@@ -11164,6 +11304,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
       minimatch: 3.1.2
+
+  three@0.183.1: {}
 
   timer2@1.0.0: {}
 
@@ -11887,3 +12029,9 @@ snapshots:
       youch-core: 0.3.3
 
   zod@3.25.76: {}
+
+  zustand@5.0.11(@types/react@19.2.14)(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4
+      use-sync-external-store: 1.6.0(react@19.2.4)


### PR DESCRIPTION
### Motivation
- Introduce a subtle star-themed visual layer to the landing page to add depth without overpowering content. 
- Provide a lightweight, route-scoped 3D background that degrades safely during SSR.

### Description
- Add `@react-three/fiber` and `three` to the app dependencies and update lockfile to enable React Three Fiber usage. 
- Add a new route-scoped component `app/src/routes/-components/star-background/index.tsx` that renders a low-density animated starfield using `Canvas`, `useFrame`, and `points`. 
- Replace the root route UI in `app/src/routes/index.tsx` with a hero layout that imports `StarBackground` and presents descriptive text and three feature cards while keeping the star effect understated. 
- Guard `StarBackground` for SSR by returning `null` when `window` is undefined.

### Testing
- Ran `pnpm run check`, which completed successfully and auto-fixed 2 files. 
- Ran `pnpm test`, which failed due to a Vitest startup error `ReferenceError: module is not defined` originating from `tiny-warning`. 
- Attempted Playwright screenshot for visual validation, but the request to `http://127.0.0.1:3000` returned `ERR_EMPTY_RESPONSE` in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998fb7b8ff4832b999b1dfbf3683441)