### PR TITLE
Refactor Panda styles with sva and update body fonts

### DIFF
--- a/.agent/rules/02_coding.md
+++ b/.agent/rules/02_coding.md
@@ -14,7 +14,8 @@
 - ファイルの命名規則としては、kebab-caseを使用してください。
 
 ## スタイルの記述
-- スタイルの記述は、Panda CSSの`css()`やrecipeを優先して記述してください。
+- スタイルの記述は、Panda CSSの`recipe` / `slot recipe` / `sva()`を優先して記述してください。
+- `styled-system/css` の `css()` は既存資産の保守を除いて新規採用せず、複数要素を持つUIは`slot recipe`または`sva()`に寄せてください。
 - `theme/`配下のChakra UI theme tokenとsemantic tokenを優先して利用してください。
 - テーマ切り替えは`next-themes`で管理してください。
 - 共有UIの見た目は`theme/recipes/`と`theme/slot-recipes/`に定義したChakra UI recipe / slot recipeを活用してください。

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ todos.json
 !.env.example
 # local tooling
 .playwright-mcp/
+*-font-check.png
 
 **/storybook-static
 **/styled-system/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,13 +52,40 @@
 - ファイルの命名規則としては、kebab-caseを使用してください。
 
 ## スタイルの記述
-- スタイルの記述は、Panda CSSの`css()`やrecipeを優先して記述してください。
+- スタイルの記述は、Panda CSSの`recipe` / `slot recipe` / `sva()`を優先して記述してください。
+- `styled-system/css` の `css()` は既存資産の保守を除いて新規採用せず、複数要素を持つUIは`slot recipe`または`sva()`に寄せてください。
 - `theme/`配下のChakra UI theme tokenとsemantic tokenを優先して利用してください。
 - テーマ切り替えは`next-themes`で管理してください。
 - 共有UIの見た目は`theme/recipes/`と`theme/slot-recipes/`に定義したChakra UI recipe / slot recipeを活用してください。
 
 記述した後は、playwright mcpを利用してスクリーンショットを取得し、スタイルの確認を行ってください。サーバーはすでに3000番ポートで起動してるので、起動しようとしないでください。widthが1200px以下の場合は、widthを1200pxに設定してください。
 
+
+
+# Gitのルール
+
+## Repository
+- [nikomaru-portfolio](https://github.com/nlkomaru/nikomaru-portfolio)
+
+## コミットメッセージ
+- コミットメッセージは英語で書き、以下のような形式で書く。
+
+```
+emoji コミットの概要
+
+```
+
+例: 
+```
+🎨 Add new page to portfolio site
+```
+
+## Issueについて
+
+- 新しい機能を追加する場合は、Issueを作成してください。
+- Issueは英語で書き、適切なラベルを追加してください。
+- 現状存在しないラベルについては、勝手に作成しないでください
+- どうしても必要である場合は、.github/labels.jsonに追加してください
 
 
 # コンポーネントについて
@@ -112,32 +139,6 @@
 -`aaa/bbb/ccc/-functions/`
     - ルート内で使用される関数
     - 各関数ごとに単体テストを実装する
-
-
-# Gitのルール
-
-## Repository
-- [nikomaru-portfolio](https://github.com/nlkomaru/nikomaru-portfolio)
-
-## コミットメッセージ
-- コミットメッセージは英語で書き、以下のような形式で書く。
-
-```
-emoji コミットの概要
-
-```
-
-例: 
-```
-🎨 Add new page to portfolio site
-```
-
-## Issueについて
-
-- 新しい機能を追加する場合は、Issueを作成してください。
-- Issueは英語で書き、適切なラベルを追加してください。
-- 現状存在しないラベルについては、勝手に作成しないでください
-- どうしても必要である場合は、.github/labels.jsonに追加してください
 
 
 ## 人格

--- a/app/package.json
+++ b/app/package.json
@@ -17,6 +17,8 @@
         "@chakra-ui/react": "^3.34.0",
         "@cloudflare/vite-plugin": "^1.13.8",
         "@emotion/react": "^11.14.0",
+        "@fontsource/noto-sans-jp": "^5.2.9",
+        "@fontsource/poppins": "^5.2.7",
         "@inlang/paraglide-js": "^2.12.0",
         "@tanstack/react-devtools": "^0.7.0",
         "@tanstack/react-router": "^1.132.0",

--- a/app/src/components/custom-cursor.tsx
+++ b/app/src/components/custom-cursor.tsx
@@ -1,11 +1,34 @@
 import { motion } from "framer-motion";
 import { useEffect, useState } from "react";
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
+
+const customCursorStyles = sva({
+    slots: ["root", "dot"],
+    base: {
+        root: {
+            position: "fixed",
+            top: 0,
+            left: 0,
+            zIndex: 9999,
+            display: { base: "none", md: "block" },
+            pointerEvents: "none",
+            mixBlendMode: "difference",
+        },
+        dot: {
+            h: "full",
+            w: "full",
+            borderRadius: "full",
+            borderWidth: "1px",
+            borderColor: "white",
+        },
+    },
+});
 
 export default function CustomCursor() {
     const [position, setPosition] = useState({ x: 0, y: 0 });
     const [isHovering, setIsHovering] = useState(false);
     const [isVisible, setIsVisible] = useState(false);
+    const styles = customCursorStyles();
 
     useEffect(() => {
         const move = (e: MouseEvent) => {
@@ -48,15 +71,7 @@ export default function CustomCursor() {
 
     return (
         <motion.div
-            className={css({
-                position: "fixed",
-                top: 0,
-                left: 0,
-                zIndex: 9999,
-                display: { base: "none", md: "block" },
-                pointerEvents: "none",
-                mixBlendMode: "difference",
-            })}
+            className={styles.root}
             animate={{
                 x: position.x - (isHovering ? 30 : 6),
                 y: position.y - (isHovering ? 30 : 6),
@@ -66,16 +81,7 @@ export default function CustomCursor() {
             }}
             transition={{ type: "spring", stiffness: 500, damping: 28, mass: 0.5 }}
         >
-            <div
-                className={css({
-                    h: "full",
-                    w: "full",
-                    borderRadius: "full",
-                    borderWidth: "1px",
-                    borderColor: "white",
-                })}
-                style={{ backgroundColor: isHovering ? "rgba(255,255,255,0.08)" : "white" }}
-            />
+            <div className={styles.dot} style={{ backgroundColor: isHovering ? "rgba(255,255,255,0.08)" : "white" }} />
         </motion.div>
     );
 }

--- a/app/src/components/header.tsx
+++ b/app/src/components/header.tsx
@@ -1,7 +1,109 @@
 import { Link, useRouterState } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
 import { deLocalizeHref, getLocale, setLocale } from "../paraglide/runtime";
+
+const headerLayoutStyles = sva({
+    slots: ["desktopNav", "brand", "navList", "localeLink", "mobileBar"],
+    base: {
+        desktopNav: {
+            position: "fixed",
+            top: 0,
+            left: 0,
+            zIndex: 50,
+            display: { base: "none", md: "flex" },
+            h: "100vh",
+            w: "14",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderRightWidth: "1px",
+            borderColor: "border.subtle",
+            bg: "bg.canvas",
+            py: "6",
+        },
+        brand: {
+            fontSize: "0.625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.3em",
+            color: "fg.default",
+            fontFamily: '"Space Mono", monospace',
+        },
+        navList: {
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "6",
+        },
+        localeLink: {
+            fontSize: "0.7rem",
+            letterSpacing: "0.2em",
+            color: "fg.subtle",
+        },
+        mobileBar: {
+            position: "fixed",
+            top: 0,
+            left: 0,
+            zIndex: 40,
+            display: { base: "block", md: "none" },
+            h: "14",
+            w: "full",
+            borderBottomWidth: "1px",
+            borderColor: "border.subtle",
+            bg: "bg.canvas",
+        },
+    },
+});
+
+const headerNavItemStyles = sva({
+    slots: ["link", "dot", "label"],
+    base: {
+        link: {
+            position: "relative",
+            display: "block",
+            _hover: {
+                '& [data-slot="nav-label"]': {
+                    opacity: 1,
+                },
+            },
+        },
+        dot: {
+            h: "2",
+            w: "2",
+            borderRadius: "full",
+            transition: "all 0.5s ease",
+        },
+        label: {
+            position: "absolute",
+            top: "50%",
+            left: "6",
+            transform: "translateY(-50%)",
+            whiteSpace: "nowrap",
+            fontSize: "0.625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.25em",
+            color: "fg.muted",
+            opacity: 0,
+            transition: "opacity 0.3s ease",
+        },
+    },
+    variants: {
+        state: {
+            active: {
+                dot: {
+                    bg: "fg.default",
+                    opacity: 1,
+                },
+            },
+            inactive: {
+                dot: {
+                    bg: "fg.subtle",
+                    opacity: 0.45,
+                },
+            },
+        },
+    },
+});
 
 export default function Header() {
     const routerState = useRouterState();
@@ -18,35 +120,14 @@ export default function Header() {
         { label: "Pictures", to: "/pictures" },
         { label: "Contact", to: "/contact" },
     ];
+    const layoutStyles = headerLayoutStyles();
 
     return (
         <>
-            <nav
-                className={css({
-                    position: "fixed",
-                    top: 0,
-                    left: 0,
-                    zIndex: 50,
-                    display: { base: "none", md: "flex" },
-                    h: "100vh",
-                    w: "14",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    borderRightWidth: "1px",
-                    borderColor: "border.subtle",
-                    bg: "bg.canvas",
-                    py: "6",
-                })}
-            >
+            <nav className={layoutStyles.desktopNav}>
                 <Link
                     to="/"
-                    className={css({
-                        fontSize: "0.625rem",
-                        textTransform: "uppercase",
-                        letterSpacing: "0.3em",
-                        color: "fg.default",
-                    })}
+                    className={layoutStyles.brand}
                     style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
                 >
                     NIKOMARU
@@ -54,46 +135,20 @@ export default function Header() {
                     PORTFOLIO
                 </Link>
 
-                <div className={css({ display: "flex", flexDirection: "column", alignItems: "center", gap: "6" })}>
+                <div className={layoutStyles.navList}>
                     {navItems.map((item, index) => {
                         const isActive = currentPath === item.to;
+                        const itemStyles = headerNavItemStyles({
+                            state: isActive ? "active" : "inactive",
+                        });
 
                         return (
-                            <Link
-                                key={item.to}
-                                to={item.to}
-                                className={css({
-                                    position: "relative",
-                                    display: "block",
-                                    _hover: { "& span": { opacity: 1 } },
-                                })}
-                            >
+                            <Link key={item.to} to={item.to} className={itemStyles.link}>
                                 <div
-                                    className={css({
-                                        h: "2",
-                                        w: "2",
-                                        borderRadius: "full",
-                                        bg: isActive ? "fg.default" : "fg.subtle",
-                                        opacity: isActive ? 1 : 0.45,
-                                        transition: "all 0.5s ease",
-                                    })}
+                                    className={itemStyles.dot}
                                     style={{ transform: isActive ? "scale(1.3)" : "scale(1)" }}
                                 />
-                                <span
-                                    className={css({
-                                        position: "absolute",
-                                        top: "50%",
-                                        left: "6",
-                                        transform: "translateY(-50%)",
-                                        whiteSpace: "nowrap",
-                                        fontSize: "0.625rem",
-                                        textTransform: "uppercase",
-                                        letterSpacing: "0.25em",
-                                        color: "fg.muted",
-                                        opacity: 0,
-                                        transition: "opacity 0.3s ease",
-                                    })}
-                                >
+                                <span className={itemStyles.label} data-slot="nav-label">
                                     {String(index + 1).padStart(2, "0")}—{item.label}
                                 </span>
                             </Link>
@@ -106,11 +161,7 @@ export default function Header() {
                     search={localeSearch}
                     hash={routerState.location.hash}
                     onClick={() => setLocale(targetLocale, { reload: false })}
-                    className={css({
-                        fontSize: "0.7rem",
-                        letterSpacing: "0.2em",
-                        color: "fg.subtle",
-                    })}
+                    className={layoutStyles.localeLink}
                     style={{ writingMode: "vertical-rl", transform: "rotate(180deg)" }}
                 >
                     <AnimatePresence mode="wait" initial={false}>
@@ -126,20 +177,7 @@ export default function Header() {
                     </AnimatePresence>
                 </Link>
             </nav>
-            <div
-                className={css({
-                    position: "fixed",
-                    top: 0,
-                    left: 0,
-                    zIndex: 40,
-                    display: { base: "block", md: "none" },
-                    h: "14",
-                    w: "full",
-                    borderBottomWidth: "1px",
-                    borderColor: "border.subtle",
-                    bg: "bg.canvas",
-                })}
-            />
+            <div className={layoutStyles.mobileBar} />
         </>
     );
 }

--- a/app/src/components/noise-overlay.tsx
+++ b/app/src/components/noise-overlay.tsx
@@ -1,15 +1,24 @@
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
+
+const noiseOverlayStyles = sva({
+    slots: ["root"],
+    base: {
+        root: {
+            position: "fixed",
+            inset: 0,
+            zIndex: 100,
+            pointerEvents: "none",
+            opacity: 0.03,
+        },
+    },
+});
 
 export default function NoiseOverlay() {
+    const styles = noiseOverlayStyles();
+
     return (
         <div
-            className={css({
-                position: "fixed",
-                inset: 0,
-                zIndex: 100,
-                pointerEvents: "none",
-                opacity: 0.03,
-            })}
+            className={styles.root}
             style={{
                 backgroundImage:
                     "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E\")",

--- a/app/src/routes/__root.tsx
+++ b/app/src/routes/__root.tsx
@@ -1,7 +1,7 @@
 import { TanStackDevtools } from "@tanstack/react-devtools";
 import { createRootRoute, HeadContent, Link, Outlet, Scripts, useRouterState } from "@tanstack/react-router";
 import { TanStackRouterDevtoolsPanel } from "@tanstack/react-router-devtools";
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
 
 import Header from "../components/header";
 import { Provider } from "../components/ui/provider";
@@ -9,6 +9,75 @@ import { m } from "../paraglide/messages";
 import { getLocale } from "../paraglide/runtime";
 
 import appCss from "../styles.css?url";
+
+const rootDocumentStyles = sva({
+    slots: ["content"],
+    base: {
+        content: {
+            minH: "100vh",
+            ml: { md: "14" },
+        },
+    },
+});
+
+const notFoundStyles = sva({
+    slots: ["root", "section", "eyebrow", "title", "description", "linkWrap", "backLink"],
+    base: {
+        root: {
+            minH: "100vh",
+            bg: "bg.canvas",
+            color: "fg.default",
+            pt: { base: "14", md: "0" },
+        },
+        section: {
+            display: "flex",
+            minH: { base: "calc(100vh - 3.5rem)", md: "100vh" },
+            flexDirection: "column",
+            justifyContent: "center",
+            gap: "6",
+            px: { base: "8", md: "20" },
+            py: { base: "12", md: "20" },
+        },
+        eyebrow: {
+            fontSize: "0.625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.45em",
+            color: "fg.muted",
+        },
+        title: {
+            fontSize: { base: "2.5rem", md: "4.5rem" },
+            lineHeight: 1,
+        },
+        description: {
+            maxW: "lg",
+            fontSize: "0.75rem",
+            lineHeight: "8",
+            color: "fg.subtle",
+        },
+        linkWrap: {
+            pt: "4",
+        },
+        backLink: {
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "3",
+            borderWidth: "1px",
+            borderColor: "border.default",
+            bg: "bg.default",
+            px: "5",
+            py: "3",
+            fontSize: "0.625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.28em",
+            color: "fg.default",
+            transition: "background-color 0.2s ease, border-color 0.2s ease",
+            _hover: {
+                bg: "bg.subtle",
+                borderColor: "border.outline",
+            },
+        },
+    },
+});
 
 export const Route = createRootRoute({
     component: RootComponent,
@@ -49,6 +118,7 @@ function RootComponent() {
 
 function RootDocument({ children }: { children: React.ReactNode }) {
     const locale = getLocale();
+    const styles = rootDocumentStyles();
 
     return (
         <html lang={locale} suppressHydrationWarning>
@@ -58,14 +128,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
             <body>
                 <Provider>
                     <Header />
-                    <div
-                        className={css({
-                            minH: "100vh",
-                            ml: { md: "14" },
-                        })}
-                    >
-                        {children}
-                    </div>
+                    <div className={styles.content}>{children}</div>
                 </Provider>
                 <TanStackDevtools
                     config={{
@@ -85,79 +148,20 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 }
 
 function NotFoundComponent() {
+    const styles = notFoundStyles();
+
     return (
-        <main
-            className={css({
-                minH: "100vh",
-                bg: "bg.canvas",
-                color: "fg.default",
-                pt: { base: "14", md: "0" },
-            })}
-        >
-            <section
-                className={css({
-                    display: "flex",
-                    minH: { base: "calc(100vh - 3.5rem)", md: "100vh" },
-                    flexDirection: "column",
-                    justifyContent: "center",
-                    gap: "6",
-                    px: { base: "8", md: "20" },
-                    py: { base: "12", md: "20" },
-                })}
-            >
-                <p
-                    className={css({
-                        fontSize: "0.625rem",
-                        textTransform: "uppercase",
-                        letterSpacing: "0.45em",
-                        color: "fg.muted",
-                    })}
-                >
-                    Not Found
-                </p>
-                <h1
-                    className={css({
-                        fontSize: { base: "2.5rem", md: "4.5rem" },
-                        lineHeight: 1,
-                    })}
-                    style={{ fontFamily: '"Cormorant Garamond", serif', fontWeight: 300 }}
-                >
+        <main className={styles.root}>
+            <section className={styles.section}>
+                <p className={styles.eyebrow}>Not Found</p>
+                <h1 className={styles.title} style={{ fontFamily: '"Cormorant Garamond", serif', fontWeight: 300 }}>
                     This page doesn&apos;t exist.
                 </h1>
-                <p
-                    className={css({
-                        maxW: "lg",
-                        fontSize: "0.75rem",
-                        lineHeight: "8",
-                        color: "fg.subtle",
-                    })}
-                    style={{ fontFamily: '"Space Mono", monospace' }}
-                >
+                <p className={styles.description} style={{ fontFamily: '"Space Mono", monospace' }}>
                     The route may have moved, or it was never published. Return to the index and continue from there.
                 </p>
-                <div className={css({ pt: "4" })}>
-                    <Link
-                        to="/"
-                        className={css({
-                            display: "inline-flex",
-                            alignItems: "center",
-                            gap: "3",
-                            borderWidth: "1px",
-                            borderColor: "border.default",
-                            bg: "bg.default",
-                            px: "5",
-                            py: "3",
-                            fontSize: "0.625rem",
-                            textTransform: "uppercase",
-                            letterSpacing: "0.28em",
-                            color: "fg.default",
-                            transition: "background-color 0.2s ease, border-color 0.2s ease",
-                            _hover: {
-                                bg: "bg.subtle",
-                                borderColor: "border.outline",
-                            },
-                        })}
-                    >
+                <div className={styles.linkWrap}>
+                    <Link to="/" className={styles.backLink}>
                         Back To Index
                     </Link>
                 </div>

--- a/app/src/routes/about/index.tsx
+++ b/app/src/routes/about/index.tsx
@@ -1,70 +1,122 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { motion } from "framer-motion";
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
+
+const aboutPageStyles = sva({
+    slots: [
+        "root",
+        "eyebrow",
+        "grid",
+        "profileColumn",
+        "profileCard",
+        "profileName",
+        "profileSummary",
+        "copyColumn",
+        "title",
+        "titleAccent",
+        "description",
+        "skills",
+        "skillPill",
+    ],
+    base: {
+        root: {
+            minH: "100vh",
+            bg: "bg.canvas",
+            px: { base: "8", md: "20" },
+            pt: { base: "24", md: "28" },
+            pb: "20",
+            color: "fg.default",
+        },
+        eyebrow: {
+            mb: "4",
+            fontSize: "0.625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.45em",
+            color: "fg.muted",
+        },
+        grid: {
+            display: "grid",
+            gap: "10",
+            gridTemplateColumns: { md: "repeat(12, minmax(0, 1fr))" },
+        },
+        profileColumn: {
+            gridColumn: { md: "span 5 / span 5" },
+        },
+        profileCard: {
+            aspectRatio: "3 / 4",
+            borderWidth: "1px",
+            borderColor: "border.default",
+            bg: "bg.default",
+            p: "6",
+            boxShadow: "sm",
+        },
+        profileName: {
+            fontSize: "xs",
+            textTransform: "uppercase",
+            letterSpacing: "0.3em",
+            color: "fg.muted",
+        },
+        profileSummary: {
+            mt: "4",
+            fontSize: "sm",
+            lineHeight: "7",
+            color: "fg.subtle",
+        },
+        copyColumn: {
+            gridColumn: { md: "span 7 / span 7" },
+        },
+        title: {
+            fontSize: { base: "2rem", md: "3.5rem" },
+            lineHeight: 1.1,
+        },
+        titleAccent: {
+            fontStyle: "italic",
+        },
+        description: {
+            mt: "8",
+            maxW: "2xl",
+            fontSize: "sm",
+            lineHeight: "8",
+            color: "fg.subtle",
+        },
+        skills: {
+            mt: "10",
+            display: "flex",
+            flexWrap: "wrap",
+            gap: "3",
+        },
+        skillPill: {
+            borderWidth: "1px",
+            borderColor: "border.default",
+            bg: "bg.default",
+            px: "4",
+            py: "2",
+            fontSize: "xs",
+            textTransform: "uppercase",
+            letterSpacing: "0.25em",
+            color: "fg.subtle",
+        },
+    },
+});
 
 export const Route = createFileRoute("/about/")({
     component: AboutPage,
 });
 
 function AboutPage() {
+    const styles = aboutPageStyles();
+
     return (
-        <div
-            className={css({
-                minH: "100vh",
-                bg: "bg.canvas",
-                px: { base: "8", md: "20" },
-                pt: { base: "24", md: "28" },
-                pb: "20",
-                color: "fg.default",
-            })}
-        >
-            <motion.p
-                initial={{ opacity: 0, y: 12 }}
-                animate={{ opacity: 1, y: 0 }}
-                className={css({
-                    mb: "4",
-                    fontSize: "0.625rem",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.45em",
-                    color: "fg.muted",
-                })}
-            >
+        <div className={styles.root}>
+            <motion.p initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className={styles.eyebrow}>
                 About
             </motion.p>
 
-            <section
-                className={css({
-                    display: "grid",
-                    gap: "10",
-                    gridTemplateColumns: { md: "repeat(12, minmax(0, 1fr))" },
-                })}
-            >
-                <motion.div
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    className={css({ gridColumn: { md: "span 5 / span 5" } })}
-                >
-                    <div
-                        className={css({
-                            aspectRatio: "3 / 4",
-                            borderWidth: "1px",
-                            borderColor: "border.default",
-                            bg: "bg.default",
-                            p: "6",
-                            boxShadow: "sm",
-                        })}
-                    >
-                        <p
-                            className={css({
-                                fontSize: "xs",
-                                textTransform: "uppercase",
-                                letterSpacing: "0.3em",
-                                color: "fg.muted",
-                            })}
-                        >
-                            Nikomaru
-                        </p>
-                        <p className={css({ mt: "4", fontSize: "sm", lineHeight: "7", color: "fg.subtle" })}>
+            <section className={styles.grid}>
+                <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className={styles.profileColumn}>
+                    <div className={styles.profileCard}>
+                        <p className={styles.profileName}>Nikomaru</p>
+                        <p className={styles.profileSummary}>
                             Web engineer focused on making polished products that are simple to maintain.
                         </p>
                     </div>
@@ -73,40 +125,27 @@ function AboutPage() {
                 <motion.div
                     initial={{ opacity: 0, x: 20 }}
                     animate={{ opacity: 1, x: 0 }}
-                    className={css({ gridColumn: { md: "span 7 / span 7" } })}
+                    className={styles.copyColumn}
                 >
-                    <h1 className={css({ fontSize: { base: "2rem", md: "3.5rem" }, lineHeight: 1.1 })}>
+                    <h1 className={styles.title}>
                         Design like an artist,
                         <br />
                         <span
-                            className={css({ fontStyle: "italic" })}
+                            className={styles.titleAccent}
                             style={{ color: "transparent", WebkitTextStroke: "1px rgba(31,41,55,0.45)" }}
                         >
                             ship like an engineer
                         </span>
                     </h1>
-                    <p className={css({ mt: "8", maxW: "2xl", fontSize: "sm", lineHeight: "8", color: "fg.subtle" })}>
+                    <p className={styles.description}>
                         I enjoy translating rough ideas into maintainable code. I care about visual quality, clean
                         component boundaries, and pragmatic delivery speed.
                     </p>
 
-                    <div className={css({ mt: "10", display: "flex", flexWrap: "wrap", gap: "3" })}>
+                    <div className={styles.skills}>
                         {["TypeScript", "React", "TanStack Start", "Cloudflare Workers", "Hono", "Storybook"].map(
                             (skill) => (
-                                <span
-                                    key={skill}
-                                    className={css({
-                                        borderWidth: "1px",
-                                        borderColor: "border.default",
-                                        bg: "bg.default",
-                                        px: "4",
-                                        py: "2",
-                                        fontSize: "xs",
-                                        textTransform: "uppercase",
-                                        letterSpacing: "0.25em",
-                                        color: "fg.subtle",
-                                    })}
-                                >
+                                <span key={skill} className={styles.skillPill}>
                                     {skill}
                                 </span>
                             ),

--- a/app/src/routes/contact/index.tsx
+++ b/app/src/routes/contact/index.tsx
@@ -1,8 +1,133 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { motion } from "framer-motion";
 import { useState } from "react";
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
 import { m } from "../../paraglide/messages";
+
+const contactPageStyles = sva({
+    slots: [
+        "root",
+        "eyebrow",
+        "title",
+        "grid",
+        "content",
+        "email",
+        "srOnly",
+        "summaryWrap",
+        "summary",
+        "aside",
+        "asideBlock",
+        "asideLabel",
+        "locationText",
+        "locationSub",
+        "socialList",
+    ],
+    base: {
+        root: {
+            minH: "100vh",
+            bg: "bg.canvas",
+            px: { base: "8", md: "20" },
+            pt: { base: "24", md: "28" },
+            pb: "20",
+            color: "fg.default",
+        },
+        eyebrow: {
+            mb: "4",
+            fontSize: "0.625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.45em",
+            color: "fg.muted",
+        },
+        title: {
+            fontSize: { base: "2.5rem", md: "4.5rem" },
+            color: "fg.default",
+        },
+        grid: {
+            mt: "12",
+            display: "grid",
+            gap: "16",
+            gridTemplateColumns: { md: "repeat(12, minmax(0, 1fr))" },
+        },
+        content: {
+            gridColumn: { md: "span 7 / span 7" },
+        },
+        email: {
+            fontSize: { base: "1.25rem", md: "2rem" },
+            color: "fg.subtle",
+            transition: "color 0.7s ease",
+            _hover: {
+                color: "fg.default",
+            },
+        },
+        srOnly: {
+            position: "absolute",
+            w: "1px",
+            h: "1px",
+            p: 0,
+            m: "-1px",
+            overflow: "hidden",
+            clip: "rect(0, 0, 0, 0)",
+            whiteSpace: "nowrap",
+            borderWidth: 0,
+        },
+        summaryWrap: {
+            mt: "10",
+            borderTopWidth: "1px",
+            borderColor: "border.subtle",
+            pt: "8",
+        },
+        summary: {
+            maxW: "xl",
+            fontSize: "0.6875rem",
+            lineHeight: "8",
+            color: "fg.muted",
+        },
+        aside: {
+            gridColumn: { md: "span 5 / span 5" },
+        },
+        asideBlock: {
+            mb: "16",
+        },
+        asideLabel: {
+            mb: "6",
+            fontSize: "0.5625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.5em",
+            color: "fg.muted",
+        },
+        locationText: {
+            fontSize: "1rem",
+            color: "fg.subtle",
+        },
+        locationSub: {
+            color: "fg.muted",
+        },
+        socialList: {},
+    },
+});
+
+const socialLinkStyles = sva({
+    slots: ["link", "name", "handle"],
+    base: {
+        link: {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderBottomWidth: "1px",
+            borderColor: "border.subtle",
+            py: "4",
+            transition: "all 0.5s ease",
+        },
+        name: {
+            fontSize: "0.6875rem",
+            transition: "color 0.5s ease",
+        },
+        handle: {
+            fontSize: "0.5625rem",
+            transition: "all 0.5s ease",
+        },
+    },
+});
 
 export const Route = createFileRoute("/contact/")({
     component: ContactPage,
@@ -15,59 +140,27 @@ const socialLinks = [
 
 function ContactPage() {
     const [hoveredSocial, setHoveredSocial] = useState<string | null>(null);
+    const styles = contactPageStyles();
 
     return (
-        <div
-            className={css({
-                minH: "100vh",
-                bg: "bg.canvas",
-                px: { base: "8", md: "20" },
-                pt: { base: "24", md: "28" },
-                pb: "20",
-                color: "fg.default",
-            })}
-        >
-            <motion.p
-                initial={{ opacity: 0, y: 12 }}
-                animate={{ opacity: 1, y: 0 }}
-                className={css({
-                    mb: "4",
-                    fontSize: "0.625rem",
-                    textTransform: "uppercase",
-                    letterSpacing: "0.45em",
-                    color: "fg.muted",
-                })}
-            >
+        <div className={styles.root}>
+            <motion.p initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className={styles.eyebrow}>
                 Contact
             </motion.p>
             <motion.h1
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
-                className={css({ fontSize: { base: "2.5rem", md: "4.5rem" }, color: "fg.default" })}
+                className={styles.title}
                 style={{ fontFamily: "'Cormorant Garamond', serif" }}
             >
                 {m["contact.heading"]()}
             </motion.h1>
 
-            <div
-                className={css({
-                    mt: "12",
-                    display: "grid",
-                    gap: "16",
-                    gridTemplateColumns: { md: "repeat(12, minmax(0, 1fr))" },
-                })}
-            >
-                <section className={css({ gridColumn: { md: "span 7 / span 7" } })}>
+            <div className={styles.grid}>
+                <section className={styles.content}>
                     <p
                         data-hover
-                        className={css({
-                            fontSize: { base: "1.25rem", md: "2rem" },
-                            color: "fg.subtle",
-                            transition: "color 0.7s ease",
-                            _hover: {
-                                color: "fg.default",
-                            },
-                        })}
+                        className={`${styles.email} mail-obfuscated`}
                         data-user="recruit"
                         data-domain="nikomaru.dev"
                         style={{
@@ -75,73 +168,39 @@ function ContactPage() {
                             fontWeight: 300,
                         }}
                     >
-                        <span
-                            style={{
-                                position: "absolute",
-                                width: "1px",
-                                height: "1px",
-                                padding: 0,
-                                margin: "-1px",
-                                overflow: "hidden",
-                                clip: "rect(0, 0, 0, 0)",
-                                whiteSpace: "nowrap",
-                                border: 0,
-                            }}
-                        >
-                            recruit@nikomaru.dev
-                        </span>
+                        <span className={styles.srOnly}>recruit@nikomaru.dev</span>
                     </p>
 
-                    <div className={css({ mt: "10", borderTopWidth: "1px", borderColor: "border.subtle", pt: "8" })}>
-                        <p
-                            className={css({ maxW: "xl", fontSize: "0.6875rem", lineHeight: "8", color: "fg.muted" })}
-                            style={{ fontFamily: "'Space Mono', monospace" }}
-                        >
+                    <div className={styles.summaryWrap}>
+                        <p className={styles.summary} style={{ fontFamily: "'Space Mono', monospace" }}>
                             {m["contact.summary"]()}
                         </p>
                     </div>
                 </section>
 
-                <aside className={css({ gridColumn: { md: "span 5 / span 5" } })}>
-                    <div className={css({ mb: "16" })}>
-                        <p
-                            className={css({
-                                mb: "6",
-                                fontSize: "0.5625rem",
-                                textTransform: "uppercase",
-                                letterSpacing: "0.5em",
-                                color: "fg.muted",
-                            })}
-                            style={{ fontFamily: "'Space Mono', monospace" }}
-                        >
+                <aside className={styles.aside}>
+                    <div className={styles.asideBlock}>
+                        <p className={styles.asideLabel} style={{ fontFamily: "'Space Mono', monospace" }}>
                             {m["contact.basedIn"]()}
                         </p>
                         <p
-                            className={css({ fontSize: "1rem", color: "fg.subtle" })}
+                            className={styles.locationText}
                             style={{ fontFamily: "'Cormorant Garamond', serif", lineHeight: 1.8 }}
                         >
                             {m["contact.location"]()}
                             <br />
-                            <span className={css({ color: "fg.muted" })}>{m["contact.locationSub"]()}</span>
+                            <span className={styles.locationSub}>{m["contact.locationSub"]()}</span>
                         </p>
                     </div>
 
-                    <div className={css({ mb: "16" })}>
-                        <p
-                            className={css({
-                                mb: "6",
-                                fontSize: "0.5625rem",
-                                textTransform: "uppercase",
-                                letterSpacing: "0.5em",
-                                color: "fg.muted",
-                            })}
-                            style={{ fontFamily: "'Space Mono', monospace" }}
-                        >
+                    <div className={styles.asideBlock}>
+                        <p className={styles.asideLabel} style={{ fontFamily: "'Space Mono', monospace" }}>
                             {m["contact.social"]()}
                         </p>
-                        <div>
+                        <div className={styles.socialList}>
                             {socialLinks.map((social) => {
                                 const isHovered = hoveredSocial === social.name;
+                                const socialStyles = socialLinkStyles();
 
                                 return (
                                     <a
@@ -152,18 +211,10 @@ function ContactPage() {
                                         data-hover
                                         onMouseEnter={() => setHoveredSocial(social.name)}
                                         onMouseLeave={() => setHoveredSocial(null)}
-                                        className={css({
-                                            display: "flex",
-                                            alignItems: "center",
-                                            justifyContent: "space-between",
-                                            borderBottomWidth: "1px",
-                                            borderColor: "border.subtle",
-                                            py: "4",
-                                            transition: "all 0.5s ease",
-                                        })}
+                                        className={socialStyles.link}
                                     >
                                         <span
-                                            className={css({ fontSize: "0.6875rem", transition: "color 0.5s ease" })}
+                                            className={socialStyles.name}
                                             style={{
                                                 fontFamily: "'Space Mono', monospace",
                                                 color: isHovered ? social.color : "var(--colors-fg-muted)",
@@ -172,7 +223,7 @@ function ContactPage() {
                                             {social.name}
                                         </span>
                                         <span
-                                            className={css({ fontSize: "0.5625rem", transition: "all 0.5s ease" })}
+                                            className={socialStyles.handle}
                                             style={{
                                                 fontFamily: "'Space Mono', monospace",
                                                 color: isHovered ? "rgba(31,41,55,0.55)" : "rgba(31,41,55,0.25)",

--- a/app/src/routes/index.tsx
+++ b/app/src/routes/index.tsx
@@ -1,10 +1,329 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { useRef, useState } from "react";
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
 import CustomCursor from "../components/custom-cursor";
 import NoiseOverlay from "../components/noise-overlay";
 import { Button } from "../components/ui";
+
+const serifDisplayStyle = {
+    fontFamily: '"Cormorant Garamond", serif',
+    fontWeight: 300,
+} as const;
+
+const monoStyle = {
+    fontFamily: '"Space Mono", monospace',
+} as const;
+
+const heroSectionStyles = sva({
+    slots: [
+        "root",
+        "content",
+        "eyebrow",
+        "titleMask",
+        "title",
+        "accentTitle",
+        "subcopy",
+        "subcopyRule",
+        "subcopyText",
+        "scrollIndicator",
+        "scrollLabel",
+        "scrollLine",
+    ],
+    base: {
+        root: {
+            position: "relative",
+            display: "flex",
+            h: "100vh",
+            alignItems: "center",
+            overflow: "hidden",
+        },
+        content: {
+            position: "relative",
+            zIndex: 10,
+            w: "full",
+            px: { base: "8", md: "20" },
+        },
+        eyebrow: {
+            mb: "8",
+            fontSize: "0.5625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.5em",
+            color: "fg.muted",
+        },
+        titleMask: {
+            overflow: "hidden",
+        },
+        title: {
+            fontSize: { base: "3rem", md: "6rem", lg: "8rem" },
+            letterSpacing: "-0.03em",
+            color: "fg.default",
+        },
+        accentTitle: {
+            fontSize: { base: "3rem", md: "6rem", lg: "8rem" },
+            letterSpacing: "-0.03em",
+            fontStyle: "italic",
+        },
+        subcopy: {
+            mt: "12",
+            display: "flex",
+            alignItems: "center",
+            gap: "8",
+        },
+        subcopyRule: {
+            h: "1px",
+            w: "16",
+            bg: "border.default",
+        },
+        subcopyText: {
+            maxW: "xs",
+            fontSize: "0.625rem",
+            letterSpacing: "0.08em",
+            color: "fg.muted",
+        },
+        scrollIndicator: {
+            position: "absolute",
+            right: { base: "8", md: "16" },
+            bottom: "10",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            gap: "3",
+        },
+        scrollLabel: {
+            fontSize: "0.5rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.3em",
+            color: "fg.subtle",
+        },
+        scrollLine: {
+            w: "1px",
+            bg: "border.default",
+        },
+    },
+});
+
+const projectCardStyles = sva({
+    slots: [
+        "root",
+        "content",
+        "leading",
+        "index",
+        "title",
+        "meta",
+        "category",
+        "year",
+        "plus",
+        "preview",
+        "previewFrame",
+        "previewImage",
+        "previewOverlay",
+    ],
+    base: {
+        root: {
+            position: "relative",
+            cursor: "pointer",
+            borderTopWidth: "1px",
+            borderColor: "border.subtle",
+            py: { base: "8", md: "12" },
+        },
+        content: {
+            display: "flex",
+            alignItems: "flex-start",
+            justifyContent: "space-between",
+            px: { base: "8", md: "20" },
+        },
+        leading: {
+            display: "flex",
+            alignItems: "flex-start",
+            gap: { base: "6", md: "12" },
+        },
+        index: {
+            mt: "2",
+            display: { base: "none", md: "block" },
+            fontSize: "0.625rem",
+            color: "fg.muted",
+        },
+        title: {
+            whiteSpace: "pre-line",
+            fontSize: { base: "1.5rem", md: "2.5rem", lg: "3.5rem" },
+            transition: "all 0.7s ease",
+        },
+        meta: {
+            mt: "4",
+            display: "flex",
+            alignItems: "center",
+            gap: "4",
+        },
+        category: {
+            fontSize: "0.5625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.3em",
+            transition: "color 0.5s ease",
+        },
+        year: {
+            fontSize: "0.5625rem",
+            color: "fg.muted",
+        },
+        plus: {
+            mt: "2",
+            display: { base: "none", md: "block" },
+            fontSize: "1.5rem",
+            color: "fg.subtle",
+        },
+        preview: {
+            pointerEvents: "none",
+            position: "absolute",
+            top: "50%",
+            right: { base: "8", md: "20" },
+            zIndex: 10,
+            display: { base: "none", md: "block" },
+            w: { md: "48", lg: "64" },
+            transform: "translateY(-50%)",
+        },
+        previewFrame: {
+            position: "relative",
+            aspectRatio: "3 / 4",
+            overflow: "hidden",
+            borderRadius: "l3",
+            boxShadow: "md",
+        },
+        previewImage: {
+            h: "full",
+            w: "full",
+            objectFit: "cover",
+            transition: "all 0.7s ease",
+        },
+        previewOverlay: {
+            position: "absolute",
+            inset: 0,
+            transition: "opacity 0.5s ease",
+        },
+    },
+});
+
+const marqueeSectionStyles = sva({
+    slots: ["root", "track", "group", "word"],
+    base: {
+        root: {
+            overflow: "hidden",
+            borderTopWidth: "1px",
+            borderBottomWidth: "1px",
+            borderColor: "border.subtle",
+            py: "16",
+        },
+        track: {
+            display: "flex",
+            alignItems: "center",
+            gap: "16",
+            whiteSpace: "nowrap",
+        },
+        group: {
+            display: "flex",
+            alignItems: "center",
+            gap: "16",
+        },
+        word: {
+            fontSize: { base: "1.5rem", md: "3rem" },
+            letterSpacing: "0.05em",
+        },
+    },
+});
+
+const homePageStyles = sva({
+    slots: [
+        "root",
+        "worksSection",
+        "worksIntro",
+        "worksEyebrow",
+        "worksDivider",
+        "ctaSection",
+        "ctaEyebrow",
+        "ctaTitle",
+        "ctaButton",
+        "footer",
+        "footerCopy",
+        "footerLinks",
+        "footerLink",
+    ],
+    base: {
+        root: {
+            minH: "100vh",
+            cursor: "none",
+            bg: "bg.canvas",
+            color: "fg.default",
+        },
+        worksSection: {
+            py: { base: "16", md: "24" },
+        },
+        worksIntro: {
+            mb: "12",
+            px: { base: "8", md: "20" },
+        },
+        worksEyebrow: {
+            fontSize: "0.5625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.5em",
+            color: "fg.muted",
+        },
+        worksDivider: {
+            borderTopWidth: "1px",
+            borderColor: "border.subtle",
+        },
+        ctaSection: {
+            px: { base: "8", md: "20" },
+            py: "32",
+            textAlign: "center",
+        },
+        ctaEyebrow: {
+            mb: "6",
+            fontSize: "0.5625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.5em",
+            color: "fg.muted",
+        },
+        ctaTitle: {
+            mb: "8",
+            fontSize: { base: "2rem", md: "4rem" },
+            color: "fg.default",
+        },
+        ctaButton: {
+            fontSize: "0.625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.3em",
+            fontFamily: '"Space Mono", monospace',
+        },
+        footer: {
+            display: "flex",
+            flexDirection: { base: "column", md: "row" },
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "4",
+            borderTopWidth: "1px",
+            borderColor: "border.subtle",
+            px: { base: "8", md: "20" },
+            py: "8",
+        },
+        footerCopy: {
+            fontSize: "0.5625rem",
+            letterSpacing: "0.08em",
+            color: "fg.muted",
+        },
+        footerLinks: {
+            display: "flex",
+            gap: "6",
+        },
+        footerLink: {
+            fontSize: "0.5625rem",
+            letterSpacing: "0.08em",
+            color: "fg.muted",
+            transition: "color 0.5s ease",
+            _hover: {
+                color: "fg.default",
+            },
+        },
+    },
+});
 
 export const Route = createFileRoute("/")({ component: App });
 
@@ -51,74 +370,43 @@ function HeroSection() {
     });
     const y = useTransform(scrollYProgress, [0, 1], [0, 200]);
     const opacity = useTransform(scrollYProgress, [0, 0.6], [1, 0]);
+    const styles = heroSectionStyles();
 
     return (
-        <section
-            ref={ref}
-            className={css({
-                position: "relative",
-                display: "flex",
-                h: "100vh",
-                alignItems: "center",
-                overflow: "hidden",
-            })}
-        >
-            <motion.div
-                style={{ y, opacity }}
-                className={css({
-                    position: "relative",
-                    zIndex: 10,
-                    w: "full",
-                    px: { base: "8", md: "20" },
-                })}
-            >
+        <section ref={ref} className={styles.root}>
+            <motion.div style={{ y, opacity }} className={styles.content}>
                 <motion.div
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     transition={{ duration: 1.2, delay: 0.2 }}
                 >
-                    <p
-                        className={css({
-                            mb: "8",
-                            fontSize: "0.5625rem",
-                            textTransform: "uppercase",
-                            letterSpacing: "0.5em",
-                            color: "fg.muted",
-                        })}
-                        style={{ fontFamily: '"Space Mono", monospace' }}
-                    >
+                    <p className={styles.eyebrow} style={monoStyle}>
                         Creative Direction & Design
                     </p>
                 </motion.div>
 
-                <div className={css({ overflow: "hidden" })}>
+                <div className={styles.titleMask}>
                     <motion.h1
                         initial={{ y: "100%" }}
                         animate={{ y: 0 }}
                         transition={{ duration: 1, delay: 0.4, ease: [0.76, 0, 0.24, 1] }}
-                        className={css({
-                            fontSize: { base: "3rem", md: "6rem", lg: "8rem" },
-                            letterSpacing: "-0.03em",
-                            color: "fg.default",
-                        })}
-                        style={{ fontFamily: '"Cormorant Garamond", serif', fontWeight: 300, lineHeight: 0.9 }}
+                        className={styles.title}
+                        style={{
+                            ...serifDisplayStyle,
+                            lineHeight: 0.9,
+                        }}
                     >
                         Make it
                     </motion.h1>
                 </div>
-                <div className={css({ overflow: "hidden" })}>
+                <div className={styles.titleMask}>
                     <motion.h1
                         initial={{ y: "100%" }}
                         animate={{ y: 0 }}
                         transition={{ duration: 1, delay: 0.55, ease: [0.76, 0, 0.24, 1] }}
-                        className={css({
-                            fontSize: { base: "3rem", md: "6rem", lg: "8rem" },
-                            letterSpacing: "-0.03em",
-                            fontStyle: "italic",
-                        })}
+                        className={styles.accentTitle}
                         style={{
-                            fontFamily: '"Cormorant Garamond", serif',
-                            fontWeight: 300,
+                            ...serifDisplayStyle,
                             lineHeight: 0.9,
                             color: "transparent",
                             WebkitTextStroke: "1px rgba(31,41,55,0.4)",
@@ -132,18 +420,10 @@ function HeroSection() {
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     transition={{ duration: 1, delay: 1.2 }}
-                    className={css({ mt: "12", display: "flex", alignItems: "center", gap: "8" })}
+                    className={styles.subcopy}
                 >
-                    <div className={css({ h: "1px", w: "16", bg: "border.default" })} />
-                    <p
-                        className={css({
-                            maxW: "xs",
-                            fontSize: "0.625rem",
-                            letterSpacing: "0.08em",
-                            color: "fg.muted",
-                        })}
-                        style={{ fontFamily: '"Space Mono", monospace', lineHeight: 1.8 }}
-                    >
+                    <div className={styles.subcopyRule} />
+                    <p className={styles.subcopyText} style={{ ...monoStyle, lineHeight: 1.8 }}>
                         Crafting visual narratives at the intersection of art and technology
                     </p>
                 </motion.div>
@@ -153,31 +433,15 @@ function HeroSection() {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: 1 }}
                 transition={{ delay: 1.8 }}
-                className={css({
-                    position: "absolute",
-                    right: { base: "8", md: "16" },
-                    bottom: "10",
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    gap: "3",
-                })}
+                className={styles.scrollIndicator}
             >
-                <span
-                    className={css({
-                        fontSize: "0.5rem",
-                        textTransform: "uppercase",
-                        letterSpacing: "0.3em",
-                        color: "fg.subtle",
-                    })}
-                    style={{ fontFamily: '"Space Mono", monospace', writingMode: "vertical-rl" }}
-                >
+                <span className={styles.scrollLabel} style={{ ...monoStyle, writingMode: "vertical-rl" }}>
                     Scroll
                 </span>
                 <motion.div
                     animate={{ height: [20, 40, 20] }}
                     transition={{ repeat: Number.POSITIVE_INFINITY, duration: 2, ease: "easeInOut" }}
-                    className={css({ w: "1px", bg: "border.default" })}
+                    className={styles.scrollLine}
                 />
             </motion.div>
         </section>
@@ -187,6 +451,7 @@ function HeroSection() {
 function ProjectCard({ project, index }: { project: (typeof projects)[0]; index: number }) {
     const [hovered, setHovered] = useState(false);
     const ref = useRef<HTMLDivElement>(null);
+    const styles = projectCardStyles();
 
     return (
         <motion.div
@@ -198,70 +463,36 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
             data-hover
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
-            className={css({
-                position: "relative",
-                cursor: "pointer",
-                borderTopWidth: "1px",
-                borderColor: "border.subtle",
-                py: { base: "8", md: "12" },
-            })}
+            className={styles.root}
         >
-            <div
-                className={css({
-                    display: "flex",
-                    alignItems: "flex-start",
-                    justifyContent: "space-between",
-                    px: { base: "8", md: "20" },
-                })}
-            >
-                <div className={css({ display: "flex", alignItems: "flex-start", gap: { base: "6", md: "12" } })}>
-                    <span
-                        className={css({
-                            mt: "2",
-                            display: { base: "none", md: "block" },
-                            fontSize: "0.625rem",
-                            color: "fg.muted",
-                        })}
-                        style={{ fontFamily: '"Space Mono", monospace' }}
-                    >
+            <div className={styles.content}>
+                <div className={styles.leading}>
+                    <span className={styles.index} style={monoStyle}>
                         {String(index + 1).padStart(2, "0")}
                     </span>
 
                     <div>
                         <h2
-                            className={css({
-                                whiteSpace: "pre-line",
-                                fontSize: { base: "1.5rem", md: "2.5rem", lg: "3.5rem" },
-                                transition: "all 0.7s ease",
-                            })}
+                            className={styles.title}
                             style={{
-                                fontFamily: '"Cormorant Garamond", serif',
-                                fontWeight: 300,
+                                ...serifDisplayStyle,
                                 lineHeight: 1,
                                 color: hovered ? project.color : "var(--colors-fg-default)",
                             }}
                         >
                             {project.title}
                         </h2>
-                        <div className={css({ mt: "4", display: "flex", alignItems: "center", gap: "4" })}>
+                        <div className={styles.meta}>
                             <span
-                                className={css({
-                                    fontSize: "0.5625rem",
-                                    textTransform: "uppercase",
-                                    letterSpacing: "0.3em",
-                                    transition: "color 0.5s ease",
-                                })}
+                                className={styles.category}
                                 style={{
-                                    fontFamily: '"Space Mono", monospace',
+                                    ...monoStyle,
                                     color: hovered ? project.color : "var(--colors-fg-muted)",
                                 }}
                             >
                                 {project.category}
                             </span>
-                            <span
-                                className={css({ fontSize: "0.5625rem", color: "fg.muted" })}
-                                style={{ fontFamily: '"Space Mono", monospace' }}
-                            >
+                            <span className={styles.year} style={monoStyle}>
                                 {project.year}
                             </span>
                         </div>
@@ -271,12 +502,7 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
                 <motion.div
                     animate={{ rotate: hovered ? 45 : 0 }}
                     transition={{ duration: 0.4 }}
-                    className={css({
-                        mt: "2",
-                        display: { base: "none", md: "block" },
-                        fontSize: "1.5rem",
-                        color: "fg.subtle",
-                    })}
+                    className={styles.plus}
                 >
                     +
                 </motion.div>
@@ -286,44 +512,22 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
                 initial={false}
                 animate={{ opacity: hovered ? 1 : 0, scale: hovered ? 1 : 0.9, x: hovered ? 0 : 20 }}
                 transition={{ duration: 0.5 }}
-                className={css({
-                    pointerEvents: "none",
-                    position: "absolute",
-                    top: "50%",
-                    right: { base: "8", md: "20" },
-                    zIndex: 10,
-                    display: { base: "none", md: "block" },
-                    w: { md: "48", lg: "64" },
-                    transform: "translateY(-50%)",
-                })}
+                className={styles.preview}
             >
-                <div
-                    className={css({
-                        position: "relative",
-                        aspectRatio: "3 / 4",
-                        overflow: "hidden",
-                        borderRadius: "l3",
-                        boxShadow: "md",
-                    })}
-                >
+                <div className={styles.previewFrame}>
                     <img
                         src={project.image}
                         alt={project.title}
-                        className={css({
-                            h: "full",
-                            w: "full",
-                            objectFit: "cover",
-                            transition: "all 0.7s ease",
-                        })}
+                        className={styles.previewImage}
                         style={{ filter: hovered ? "grayscale(0%)" : "grayscale(100%)" }}
                     />
                     <div
-                        className={css({
-                            position: "absolute",
-                            inset: 0,
-                            transition: "opacity 0.5s ease",
-                        })}
-                        style={{ backgroundColor: project.color, opacity: hovered ? 0.1 : 0, mixBlendMode: "overlay" }}
+                        className={styles.previewOverlay}
+                        style={{
+                            backgroundColor: project.color,
+                            opacity: hovered ? 0.1 : 0,
+                            mixBlendMode: "overlay",
+                        }}
                     />
                 </div>
             </motion.div>
@@ -334,31 +538,23 @@ function ProjectCard({ project, index }: { project: (typeof projects)[0]; index:
 function MarqueeSection() {
     const marqueeRows = ["DESIGN", "DEVELOP", "CREATE", "INSPIRE", "INNOVATE", "EXPLORE"];
     const marqueeGroups = ["group-1", "group-2", "group-3"];
+    const styles = marqueeSectionStyles();
 
     return (
-        <div
-            className={css({
-                overflow: "hidden",
-                borderTopWidth: "1px",
-                borderBottomWidth: "1px",
-                borderColor: "border.subtle",
-                py: "16",
-            })}
-        >
+        <div className={styles.root}>
             <motion.div
                 animate={{ x: [0, -1920] }}
                 transition={{ repeat: Number.POSITIVE_INFINITY, duration: 30, ease: "linear" }}
-                className={css({ display: "flex", alignItems: "center", gap: "16", whiteSpace: "nowrap" })}
+                className={styles.track}
             >
                 {marqueeGroups.map((groupKey) => (
-                    <div key={groupKey} className={css({ display: "flex", alignItems: "center", gap: "16" })}>
+                    <div key={groupKey} className={styles.group}>
                         {marqueeRows.map((word) => (
                             <span
                                 key={`${groupKey}-${word}`}
-                                className={css({ fontSize: { base: "1.5rem", md: "3rem" }, letterSpacing: "0.05em" })}
+                                className={styles.word}
                                 style={{
-                                    fontFamily: '"Cormorant Garamond", serif',
-                                    fontWeight: 300,
+                                    ...serifDisplayStyle,
                                     color: "transparent",
                                     WebkitTextStroke: "0.5px rgba(31,41,55,0.16)",
                                 }}
@@ -374,55 +570,43 @@ function MarqueeSection() {
 }
 
 function App() {
+    const styles = homePageStyles();
+
     return (
-        <div className={css({ minH: "100vh", cursor: "none", bg: "bg.canvas", color: "fg.default" })}>
+        <div className={styles.root}>
             <CustomCursor />
             <NoiseOverlay />
             <HeroSection />
             <MarqueeSection />
 
-            <section className={css({ py: { base: "16", md: "24" } })}>
-                <div className={css({ mb: "12", px: { base: "8", md: "20" } })}>
-                    <p
-                        className={css({
-                            fontSize: "0.5625rem",
-                            textTransform: "uppercase",
-                            letterSpacing: "0.5em",
-                            color: "fg.muted",
-                        })}
-                        style={{ fontFamily: '"Space Mono", monospace' }}
-                    >
+            <section className={styles.worksSection}>
+                <div className={styles.worksIntro}>
+                    <p className={styles.worksEyebrow} style={monoStyle}>
                         Selected Works
                     </p>
                 </div>
                 {projects.map((project, index) => (
                     <ProjectCard key={project.id} project={project} index={index} />
                 ))}
-                <div className={css({ borderTopWidth: "1px", borderColor: "border.subtle" })} />
+                <div className={styles.worksDivider} />
             </section>
 
-            <section className={css({ px: { base: "8", md: "20" }, py: "32", textAlign: "center" })}>
+            <section className={styles.ctaSection}>
                 <motion.div
                     initial={{ opacity: 0, y: 30 }}
                     whileInView={{ opacity: 1, y: 0 }}
                     viewport={{ once: true }}
                     transition={{ duration: 0.8 }}
                 >
-                    <p
-                        className={css({
-                            mb: "6",
-                            fontSize: "0.5625rem",
-                            textTransform: "uppercase",
-                            letterSpacing: "0.5em",
-                            color: "fg.muted",
-                        })}
-                        style={{ fontFamily: '"Space Mono", monospace' }}
-                    >
+                    <p className={styles.ctaEyebrow} style={monoStyle}>
                         Let&apos;s collaborate
                     </p>
                     <h2
-                        className={css({ mb: "8", fontSize: { base: "2rem", md: "4rem" }, color: "fg.default" })}
-                        style={{ fontFamily: '"Cormorant Garamond", serif', fontWeight: 300, lineHeight: 1.1 }}
+                        className={styles.ctaTitle}
+                        style={{
+                            ...serifDisplayStyle,
+                            lineHeight: 1.1,
+                        }}
                     >
                         Have a project
                         <br />
@@ -436,44 +620,17 @@ function App() {
                             in mind?
                         </span>
                     </h2>
-                    <Button
-                        as={Link}
-                        to="/contact"
-                        data-hover
-                        variant="outline"
-                        size="lg"
-                        className={css({
-                            fontSize: "0.625rem",
-                            textTransform: "uppercase",
-                            letterSpacing: "0.3em",
-                            fontFamily: '"Space Mono", monospace',
-                        })}
-                    >
+                    <Button as={Link} to="/contact" data-hover variant="outline" size="lg" className={styles.ctaButton}>
                         Start a conversation
                     </Button>
                 </motion.div>
             </section>
 
-            <footer
-                className={css({
-                    display: "flex",
-                    flexDirection: { base: "column", md: "row" },
-                    alignItems: "center",
-                    justifyContent: "space-between",
-                    gap: "4",
-                    borderTopWidth: "1px",
-                    borderColor: "border.subtle",
-                    px: { base: "8", md: "20" },
-                    py: "8",
-                })}
-            >
-                <p
-                    className={css({ fontSize: "0.5625rem", letterSpacing: "0.08em", color: "fg.muted" })}
-                    style={{ fontFamily: '"Space Mono", monospace' }}
-                >
+            <footer className={styles.footer}>
+                <p className={styles.footerCopy} style={monoStyle}>
                     &copy; 2026 — All rights reserved
                 </p>
-                <div className={css({ display: "flex", gap: "6" })}>
+                <div className={styles.footerLinks}>
                     {[
                         { label: "Tw", href: "https://x.com/" },
                         { label: "Ig", href: "https://www.instagram.com/" },
@@ -486,16 +643,8 @@ function App() {
                             target="_blank"
                             rel="noreferrer"
                             data-hover
-                            className={css({
-                                fontSize: "0.5625rem",
-                                letterSpacing: "0.08em",
-                                color: "fg.muted",
-                                transition: "color 0.5s ease",
-                                _hover: {
-                                    color: "fg.default",
-                                },
-                            })}
-                            style={{ fontFamily: '"Space Mono", monospace' }}
+                            className={styles.footerLink}
+                            style={monoStyle}
                         >
                             {social.label}
                         </a>

--- a/app/src/routes/talks/-components/slide-card.tsx
+++ b/app/src/routes/talks/-components/slide-card.tsx
@@ -1,6 +1,50 @@
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
 import { Card } from "../../../components/ui";
 import type { Slide } from "../-types/slide";
+
+const slideCardStyles = sva({
+    slots: ["link", "card", "imageWrap", "image", "body", "title", "updatedAt"],
+    base: {
+        link: {
+            display: "block",
+            w: "full",
+        },
+        card: {
+            w: "full",
+            overflow: "hidden",
+            transition: "box-shadow 0.2s ease",
+            _hover: {
+                boxShadow: "md",
+            },
+        },
+        imageWrap: {
+            borderBottomWidth: "1px",
+            borderColor: "border.muted",
+        },
+        image: {
+            aspectRatio: "16 / 9",
+            w: "full",
+            h: "auto",
+            objectFit: "cover",
+        },
+        body: {
+            gap: "2",
+            px: { base: "3", lg: "4" },
+            py: { base: "3", lg: "4" },
+        },
+        title: {
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            fontSize: { base: "sm", lg: "lg" },
+            color: "fg.default",
+        },
+        updatedAt: {
+            fontSize: { base: "2xs", lg: "sm" },
+            color: "fg.muted",
+        },
+    },
+});
 
 interface SlideCardProps {
     slide: Slide;
@@ -8,20 +52,12 @@ interface SlideCardProps {
 }
 
 export default function SlideCard({ slide, priority = false }: SlideCardProps) {
+    const styles = slideCardStyles();
+
     return (
-        <a href={slide.link} target="_blank" rel="noopener noreferrer" className={css({ display: "block", w: "full" })}>
-            <Card.Root
-                variant="outline"
-                className={css({
-                    w: "full",
-                    overflow: "hidden",
-                    transition: "box-shadow 0.2s ease",
-                    _hover: {
-                        boxShadow: "md",
-                    },
-                })}
-            >
-                <div className={css({ borderBottomWidth: "1px", borderColor: "border.muted" })}>
+        <a href={slide.link} target="_blank" rel="noopener noreferrer" className={styles.link}>
+            <Card.Root variant="outline" className={styles.card}>
+                <div className={styles.imageWrap}>
                     <img
                         src={slide.image}
                         alt={slide.title}
@@ -30,28 +66,13 @@ export default function SlideCard({ slide, priority = false }: SlideCardProps) {
                         loading={priority ? "eager" : "lazy"}
                         decoding={priority ? "sync" : "async"}
                         fetchPriority={priority ? "high" : "auto"}
-                        className={css({
-                            aspectRatio: "16 / 9",
-                            w: "full",
-                            h: "auto",
-                            objectFit: "cover",
-                        })}
+                        className={styles.image}
                     />
                 </div>
 
-                <Card.Body className={css({ gap: "2", px: { base: "3", lg: "4" }, py: { base: "3", lg: "4" } })}>
-                    <p
-                        className={css({
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                            fontSize: { base: "sm", lg: "lg" },
-                            color: "fg.default",
-                        })}
-                    >
-                        {slide.title}
-                    </p>
-                    <p className={css({ fontSize: { base: "2xs", lg: "sm" }, color: "fg.muted" })}>
+                <Card.Body className={styles.body}>
+                    <p className={styles.title}>{slide.title}</p>
+                    <p className={styles.updatedAt}>
                         最終更新日: {slide.lastUpdate ? new Date(slide.lastUpdate).toISOString().split("T")[0] : "N/A"}
                     </p>
                 </Card.Body>

--- a/app/src/routes/talks/index.tsx
+++ b/app/src/routes/talks/index.tsx
@@ -1,11 +1,38 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { AnimatePresence, motion } from "framer-motion";
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
 import { m } from "../../paraglide/messages";
 import SlideCard from "./-components/slide-card";
 import { getSlides } from "./-functions/get-slides";
 
 const ABOVE_FOLD_COUNT = 3;
+
+const talksPageStyles = sva({
+    slots: ["root", "title", "grid"],
+    base: {
+        root: {
+            maxW: "6xl",
+            mx: "auto",
+            px: "4",
+            py: "8",
+        },
+        title: {
+            mb: "8",
+            fontSize: "xl",
+            color: "fg.default",
+        },
+        grid: {
+            display: "grid",
+            gridTemplateColumns: {
+                base: "1fr",
+                md: "repeat(2, minmax(0, 1fr))",
+                lg: "repeat(3, minmax(0, 1fr))",
+            },
+            gap: "8",
+            w: "full",
+        },
+    },
+});
 
 export const Route = createFileRoute("/talks/")({
     head: ({ loaderData }) => {
@@ -31,13 +58,14 @@ export const Route = createFileRoute("/talks/")({
 function SlidesPage() {
     const slides = Route.useLoaderData();
     const publicSlides = slides.filter((slide) => slide.type === "public");
+    const styles = talksPageStyles();
 
     return (
-        <div className={css({ maxW: "6xl", mx: "auto", px: "4", py: "8" })}>
+        <div className={styles.root}>
             <AnimatePresence mode="wait" initial={false}>
                 <motion.h1
                     key={m.slidesTitle()}
-                    className={css({ mb: "8", fontSize: "xl", color: "fg.default" })}
+                    className={styles.title}
                     initial={{ opacity: 0, y: 6 }}
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -6 }}
@@ -47,18 +75,7 @@ function SlidesPage() {
                 </motion.h1>
             </AnimatePresence>
 
-            <div
-                className={css({
-                    display: "grid",
-                    gridTemplateColumns: {
-                        base: "1fr",
-                        md: "repeat(2, minmax(0, 1fr))",
-                        lg: "repeat(3, minmax(0, 1fr))",
-                    },
-                    gap: "8",
-                    w: "full",
-                })}
-            >
+            <div className={styles.grid}>
                 {publicSlides.map((slide, i) => (
                     <SlideCard slide={slide} key={slide.id} priority={i < ABOVE_FOLD_COUNT} />
                 ))}

--- a/app/src/routes/works/index.tsx
+++ b/app/src/routes/works/index.tsx
@@ -1,7 +1,164 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { motion, useScroll, useTransform } from "framer-motion";
 import { useRef, useState } from "react";
-import { css } from "styled-system/css";
+import { sva } from "styled-system/css";
+
+const serifDisplayStyle = {
+    fontFamily: "'Cormorant Garamond', serif",
+    fontWeight: 300,
+} as const;
+
+const monoStyle = {
+    fontFamily: "'Space Mono', monospace",
+} as const;
+
+const worksPageStyles = sva({
+    slots: ["root", "hero", "eyebrow", "title", "list"],
+    base: {
+        root: {
+            minH: "100vh",
+            bg: "bg.canvas",
+        },
+        hero: {
+            px: { base: "8", md: "20" },
+            pt: { base: "20", md: "32" },
+            pb: "8",
+        },
+        eyebrow: {
+            mb: "4",
+            fontSize: "0.5625rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.5em",
+            color: "fg.muted",
+        },
+        title: {
+            fontSize: { base: "2.5rem", md: "5rem" },
+            color: "fg.default",
+        },
+        list: {
+            px: { base: "8", md: "12" },
+        },
+    },
+});
+
+const workItemStyles = sva({
+    slots: [
+        "root",
+        "mediaColumn",
+        "mediaFrame",
+        "mediaImage",
+        "mediaOverlay",
+        "count",
+        "copyColumn",
+        "meta",
+        "title",
+        "description",
+        "action",
+        "actionLine",
+        "actionText",
+    ],
+    base: {
+        root: {
+            display: "grid",
+            cursor: "pointer",
+            gridTemplateColumns: { base: "1fr", md: "repeat(12, minmax(0, 1fr))" },
+            alignItems: "center",
+            gap: { base: "6", md: "0" },
+            py: { base: "12", md: "20" },
+        },
+        mediaColumn: {
+            position: "relative",
+            overflow: "hidden",
+            gridColumn: { md: "span 6 / span 6" },
+        },
+        mediaFrame: {
+            position: "relative",
+            aspectRatio: "4 / 5",
+            overflow: "hidden",
+        },
+        mediaImage: {
+            h: "120%",
+            w: "full",
+            objectFit: "cover",
+            transition: "all 1s ease",
+        },
+        mediaOverlay: {
+            position: "absolute",
+            inset: 0,
+            transition: "all 0.7s ease",
+        },
+        count: {
+            position: "absolute",
+            top: "4",
+            left: "4",
+            fontSize: "0.5rem",
+            letterSpacing: "0.3em",
+            transition: "color 0.5s ease",
+        },
+        copyColumn: {
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+            gridColumn: { md: "span 5 / span 5" },
+        },
+        meta: {
+            mb: "4",
+            fontSize: "0.5rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.4em",
+            transition: "color 0.5s ease",
+        },
+        title: {
+            fontSize: { base: "1.75rem", md: "2.5rem" },
+            transition: "color 0.7s ease",
+        },
+        description: {
+            mt: "4",
+            maxW: "sm",
+            fontSize: "0.6875rem",
+            transition: "color 0.5s ease",
+        },
+        action: {
+            mt: "8",
+            display: "flex",
+            alignItems: "center",
+            gap: "3",
+        },
+        actionLine: {
+            h: "1px",
+        },
+        actionText: {
+            fontSize: "0.5rem",
+            textTransform: "uppercase",
+            letterSpacing: "0.3em",
+            transition: "color 0.5s ease",
+        },
+    },
+    variants: {
+        parity: {
+            even: {
+                mediaColumn: {
+                    gridColumnStart: { md: "1" },
+                },
+                copyColumn: {
+                    gridColumnStart: { md: "8" },
+                    pl: { md: "12" },
+                    pr: { md: "0" },
+                },
+            },
+            odd: {
+                mediaColumn: {
+                    gridColumnStart: { md: "7" },
+                },
+                copyColumn: {
+                    gridColumnStart: { md: "1" },
+                    pl: { md: "0" },
+                    pr: { md: "12" },
+                },
+            },
+        },
+    },
+});
 
 const works = [
     {
@@ -73,6 +230,7 @@ function WorkItem({ work, index }: { work: (typeof works)[0]; index: number }) {
     });
     const imgY = useTransform(scrollYProgress, [0, 1], [60, -60]);
     const isEven = index % 2 === 0;
+    const styles = workItemStyles({ parity: isEven ? "even" : "odd" });
 
     return (
         <motion.div
@@ -83,42 +241,18 @@ function WorkItem({ work, index }: { work: (typeof works)[0]; index: number }) {
             transition={{ duration: 0.8 }}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
-            className={css({
-                display: "grid",
-                cursor: "pointer",
-                gridTemplateColumns: { base: "1fr", md: "repeat(12, minmax(0, 1fr))" },
-                alignItems: "center",
-                gap: { base: "6", md: "0" },
-                py: { base: "12", md: "20" },
-            })}
+            className={styles.root}
         >
-            <div
-                className={css({
-                    position: "relative",
-                    overflow: "hidden",
-                    gridColumn: { md: "span 6 / span 6" },
-                    gridColumnStart: { md: isEven ? "1" : "7" },
-                })}
-                style={{ order: isEven ? 1 : 2 }}
-            >
-                <div className={css({ position: "relative", aspectRatio: "4 / 5", overflow: "hidden" })}>
+            <div className={styles.mediaColumn} style={{ order: isEven ? 1 : 2 }}>
+                <div className={styles.mediaFrame}>
                     <motion.img
                         src={work.image}
                         alt={work.title}
-                        className={css({
-                            h: "120%",
-                            w: "full",
-                            objectFit: "cover",
-                            transition: "all 1s ease",
-                        })}
+                        className={styles.mediaImage}
                         style={{ y: imgY, filter: hovered ? "grayscale(0%)" : "grayscale(100%)" }}
                     />
                     <div
-                        className={css({
-                            position: "absolute",
-                            inset: 0,
-                            transition: "all 0.7s ease",
-                        })}
+                        className={styles.mediaOverlay}
                         style={{
                             background: hovered ? `linear-gradient(135deg, ${work.color}15, transparent)` : "none",
                         }}
@@ -126,16 +260,9 @@ function WorkItem({ work, index }: { work: (typeof works)[0]; index: number }) {
                 </div>
 
                 <div
-                    className={css({
-                        position: "absolute",
-                        top: "4",
-                        left: "4",
-                        fontSize: "0.5rem",
-                        letterSpacing: "0.3em",
-                        transition: "color 0.5s ease",
-                    })}
+                    className={styles.count}
                     style={{
-                        fontFamily: "'Space Mono', monospace",
+                        ...monoStyle,
                         color: hovered ? work.color : "rgba(31,41,55,0.4)",
                     }}
                 >
@@ -143,28 +270,11 @@ function WorkItem({ work, index }: { work: (typeof works)[0]; index: number }) {
                 </div>
             </div>
 
-            <div
-                className={css({
-                    display: "flex",
-                    flexDirection: "column",
-                    justifyContent: "center",
-                    gridColumn: { md: "span 5 / span 5" },
-                    gridColumnStart: { md: isEven ? "8" : "1" },
-                    pl: { md: isEven ? "12" : "0" },
-                    pr: { md: isEven ? "0" : "12" },
-                })}
-                style={{ order: isEven ? 2 : 1 }}
-            >
+            <div className={styles.copyColumn} style={{ order: isEven ? 2 : 1 }}>
                 <span
-                    className={css({
-                        mb: "4",
-                        fontSize: "0.5rem",
-                        textTransform: "uppercase",
-                        letterSpacing: "0.4em",
-                        transition: "color 0.5s ease",
-                    })}
+                    className={styles.meta}
                     style={{
-                        fontFamily: "'Space Mono', monospace",
+                        ...monoStyle,
                         color: hovered ? work.color : "var(--colors-fg-muted)",
                     }}
                 >
@@ -172,13 +282,9 @@ function WorkItem({ work, index }: { work: (typeof works)[0]; index: number }) {
                 </span>
 
                 <h2
-                    className={css({
-                        fontSize: { base: "1.75rem", md: "2.5rem" },
-                        transition: "color 0.7s ease",
-                    })}
+                    className={styles.title}
                     style={{
-                        fontFamily: "'Cormorant Garamond', serif",
-                        fontWeight: 300,
+                        ...serifDisplayStyle,
                         lineHeight: 1.1,
                         color: hovered ? "var(--colors-fg-default)" : "rgba(31,41,55,0.7)",
                     }}
@@ -187,14 +293,9 @@ function WorkItem({ work, index }: { work: (typeof works)[0]; index: number }) {
                 </h2>
 
                 <p
-                    className={css({
-                        mt: "4",
-                        maxW: "sm",
-                        fontSize: "0.6875rem",
-                        transition: "color 0.5s ease",
-                    })}
+                    className={styles.description}
                     style={{
-                        fontFamily: "'Space Mono', monospace",
+                        ...monoStyle,
                         lineHeight: 1.8,
                         color: hovered ? "rgba(31,41,55,0.7)" : "rgba(31,41,55,0.45)",
                     }}
@@ -202,22 +303,17 @@ function WorkItem({ work, index }: { work: (typeof works)[0]; index: number }) {
                     {work.description}
                 </p>
 
-                <div className={css({ mt: "8", display: "flex", alignItems: "center", gap: "3" })}>
+                <div className={styles.action}>
                     <motion.div
                         animate={{ width: hovered ? 48 : 24 }}
                         transition={{ duration: 0.5 }}
-                        className={css({ h: "1px" })}
+                        className={styles.actionLine}
                         style={{ backgroundColor: hovered ? work.color : "rgba(31,41,55,0.16)" }}
                     />
                     <span
-                        className={css({
-                            fontSize: "0.5rem",
-                            textTransform: "uppercase",
-                            letterSpacing: "0.3em",
-                            transition: "color 0.5s ease",
-                        })}
+                        className={styles.actionText}
                         style={{
-                            fontFamily: "'Space Mono', monospace",
+                            ...monoStyle,
                             color: hovered ? work.color : "rgba(31,41,55,0.45)",
                         }}
                     >
@@ -230,31 +326,23 @@ function WorkItem({ work, index }: { work: (typeof works)[0]; index: number }) {
 }
 
 function WorksPage() {
+    const styles = worksPageStyles();
+
     return (
-        <div className={css({ minH: "100vh", bg: "bg.canvas" })}>
-            <section className={css({ px: { base: "8", md: "20" }, pt: { base: "20", md: "32" }, pb: "8" })}>
+        <div className={styles.root}>
+            <section className={styles.hero}>
                 <motion.div
                     initial={{ opacity: 0, y: 20 }}
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ duration: 0.8 }}
                 >
-                    <p
-                        className={css({
-                            mb: "4",
-                            fontSize: "0.5625rem",
-                            textTransform: "uppercase",
-                            letterSpacing: "0.5em",
-                            color: "fg.muted",
-                        })}
-                        style={{ fontFamily: "'Space Mono', monospace" }}
-                    >
+                    <p className={styles.eyebrow} style={monoStyle}>
                         Archive - {works.length} Projects
                     </p>
                     <h1
-                        className={css({ fontSize: { base: "2.5rem", md: "5rem" }, color: "fg.default" })}
+                        className={styles.title}
                         style={{
-                            fontFamily: "'Cormorant Garamond', serif",
-                            fontWeight: 300,
+                            ...serifDisplayStyle,
                             lineHeight: 1,
                         }}
                     >
@@ -263,7 +351,7 @@ function WorksPage() {
                 </motion.div>
             </section>
 
-            <section className={css({ px: { base: "8", md: "12" } })}>
+            <section className={styles.list}>
                 {works.map((work, index) => (
                     <WorkItem key={work.id} work={work} index={index} />
                 ))}

--- a/app/src/styles.css
+++ b/app/src/styles.css
@@ -1,3 +1,9 @@
+@import "@fontsource/poppins/400.css";
+@import "@fontsource/poppins/500.css";
+@import "@fontsource/poppins/600.css";
+@import "@fontsource/noto-sans-jp/400.css";
+@import "@fontsource/noto-sans-jp/500.css";
+@import "@fontsource/noto-sans-jp/700.css";
 @import url("https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400&display=swap");
 @layer reset, base, tokens, recipes, utilities;
 

--- a/app/theme/global-css.ts
+++ b/app/theme/global-css.ts
@@ -44,7 +44,7 @@ export const globalCss = defineGlobalStyles({
         background: "bg.canvas",
         color: "fg.default",
         fontFamily:
-            '"Space Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+            '"Poppins", "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
     },
     "*::placeholder, *[data-placeholder]": {
         color: "fg.muted/80",

--- a/app/theme/tokens/fonts.ts
+++ b/app/theme/tokens/fonts.ts
@@ -2,10 +2,10 @@ import { defineTokens } from "@chakra-ui/react";
 
 export const fonts = defineTokens.fonts({
     heading: {
-        value: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+        value: '"Poppins", "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
     },
     body: {
-        value: 'Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
+        value: '"Poppins", "Noto Sans JP", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
     },
     mono: {
         value: 'SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.14)(react@19.2.4)
+      '@fontsource/noto-sans-jp':
+        specifier: ^5.2.9
+        version: 5.2.9
+      '@fontsource/poppins':
+        specifier: ^5.2.7
+        version: 5.2.7
       '@inlang/paraglide-js':
         specifier: ^2.12.0
         version: 2.15.1(babel-plugin-macros@3.1.0)
@@ -1181,6 +1187,9 @@ packages:
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@fontsource/noto-sans-jp@5.2.9':
+    resolution: {integrity: sha512-6yVGiofnrnbiJjU8ch4JGSs2HqyozxMvsVyVmFwOnDH3u//qQKLqmKM4n0lqN0637uaJNzUW9nIJqbbMgHVQzw==}
 
   '@fontsource/poppins@5.2.7':
     resolution: {integrity: sha512-6uQyPmseo4FgI97WIhA4yWRlNaoLk4vSDK/PyRwdqqZb5zAEuc+Kunt8JTMcsHYUEGYBtN15SNkMajMdqUSUmg==}
@@ -7896,6 +7905,8 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@fontsource/noto-sans-jp@5.2.9': {}
 
   '@fontsource/poppins@5.2.7': {}
 


### PR DESCRIPTION
## Summary
- migrate app-facing Panda styling from `styled-system/css` `css()` usage to `sva()`-based slot styling
- switch body typography to `Poppins` and `Noto Sans JP` via `fontsource` while keeping the header brand font unchanged
- update agent rules/build output and ignore local screenshot artifacts in `.gitignore`

## Verification
- `pnpm run check`
- `pnpm --filter @nikomaru-portfolio/app build`

## Notes
- `pnpm --filter @nikomaru-portfolio/app exec tsc --noEmit` still fails because of the existing generated Panda type issue in `app/styled-system/recipes/switch.d.ts` (`switch` identifier), which is outside this change set.