### PR TITLE
[codex] Update slide metadata handling

### DIFF
--- a/app/src/routes/talks/-components/slide-card-thumbnail.tsx
+++ b/app/src/routes/talks/-components/slide-card-thumbnail.tsx
@@ -64,11 +64,10 @@ const slideCardThumbnailStyles = sva({
 
 interface SlideCardThumbnailProps {
     slide: Slide;
-    priority: boolean;
     metaLabel: string;
 }
 
-export default function SlideCardThumbnail({ slide, priority, metaLabel }: SlideCardThumbnailProps) {
+export default function SlideCardThumbnail({ slide, metaLabel }: SlideCardThumbnailProps) {
     const styles = slideCardThumbnailStyles();
     const fallbackStyle = slide.thumbnailBlurhash ? getBlurhashBackground(slide.thumbnailBlurhash) : undefined;
 
@@ -83,9 +82,9 @@ export default function SlideCardThumbnail({ slide, priority, metaLabel }: Slide
                         alt=""
                         width={576}
                         height={324}
-                        loading={priority ? "eager" : "lazy"}
-                        decoding={priority ? "sync" : "async"}
-                        fetchPriority={priority ? "high" : "auto"}
+                        loading="lazy"
+                        decoding="async"
+                        fetchPriority="auto"
                         className={styles.image}
                     />
                 ) : null}

--- a/app/src/routes/talks/-components/slide-card-thumbnail.tsx
+++ b/app/src/routes/talks/-components/slide-card-thumbnail.tsx
@@ -1,8 +1,9 @@
 import { sva } from "styled-system/css";
+import { getBlurhashBackground } from "@/routes/-functions/blurhash-background";
 import type { Slide } from "../-types/slide";
 
 const slideCardThumbnailStyles = sva({
-    slots: ["metaText", "imageLink", "image"],
+    slots: ["metaText", "imageLink", "image", "fallback"],
     base: {
         metaText: {
             display: { base: "none", md: "block" },
@@ -52,6 +53,12 @@ const slideCardThumbnailStyles = sva({
             transition: "opacity 0.18s ease, transform 0.18s ease",
             pointerEvents: "none",
         },
+        fallback: {
+            position: "absolute",
+            inset: 0,
+            bg: "bg.muted",
+            pointerEvents: "none",
+        },
     },
 });
 
@@ -63,21 +70,25 @@ interface SlideCardThumbnailProps {
 
 export default function SlideCardThumbnail({ slide, priority, metaLabel }: SlideCardThumbnailProps) {
     const styles = slideCardThumbnailStyles();
+    const fallbackStyle = slide.thumbnailBlurhash ? getBlurhashBackground(slide.thumbnailBlurhash) : undefined;
 
     return (
         <>
             <span className={styles.metaText}>{metaLabel}</span>
             <a href={slide.slideUrl} className={styles.imageLink} aria-label={`${slide.title} — open slides`}>
-                <img
-                    src={slide.image}
-                    alt=""
-                    width={576}
-                    height={324}
-                    loading={priority ? "eager" : "lazy"}
-                    decoding={priority ? "sync" : "async"}
-                    fetchPriority={priority ? "high" : "auto"}
-                    className={styles.image}
-                />
+                <span className={styles.fallback} style={fallbackStyle} aria-hidden="true" />
+                {slide.thumbnailImage ? (
+                    <img
+                        src={slide.thumbnailImage}
+                        alt=""
+                        width={576}
+                        height={324}
+                        loading={priority ? "eager" : "lazy"}
+                        decoding={priority ? "sync" : "async"}
+                        fetchPriority={priority ? "high" : "auto"}
+                        className={styles.image}
+                    />
+                ) : null}
             </a>
         </>
     );

--- a/app/src/routes/talks/-components/slide-card.tsx
+++ b/app/src/routes/talks/-components/slide-card.tsx
@@ -62,10 +62,9 @@ function formatShortDate(slide: Slide): string {
     return `${month} ${day}`;
 }
 
-// 右側のメタ情報「TAG · NUM」を生成する。tagが無ければ種別ラベルにフォールバック。
+// 右側のメタ情報にはページ数を表示する。
 function formatMeta(slide: Slide): string {
-    const primaryTag = slide.tags[0] ?? slide.type;
-    return primaryTag.toUpperCase();
+    return `${slide.pageCount}P`;
 }
 
 export default function SlideCard({ slide, index, priority = false }: SlideCardProps) {

--- a/app/src/routes/talks/-components/slide-card.tsx
+++ b/app/src/routes/talks/-components/slide-card.tsx
@@ -44,7 +44,6 @@ interface SlideCardProps {
     slide: Slide;
     // 年内のインデックス（00始まり、2桁ゼロ詰めで表示）
     index: number;
-    priority?: boolean;
 }
 
 // 短い「FEB 12」形式の日付ラベルを生成する。プレゼン日が無ければ最終更新日を使う。
@@ -67,7 +66,7 @@ function formatMeta(slide: Slide): string {
     return `${slide.pageCount}P`;
 }
 
-export default function SlideCard({ slide, index, priority = false }: SlideCardProps) {
+export default function SlideCard({ slide, index }: SlideCardProps) {
     const styles = slideCardStyles();
 
     const indexLabel = String(index + 1).padStart(2, "0");
@@ -81,7 +80,7 @@ export default function SlideCard({ slide, index, priority = false }: SlideCardP
                     <SlideCardBody slide={slide} indexLabel={indexLabel} dateLabel={dateLabel} />
                 </div>
                 <div className={styles.right}>
-                    <SlideCardThumbnail slide={slide} priority={priority} metaLabel={metaLabel} />
+                    <SlideCardThumbnail slide={slide} metaLabel={metaLabel} />
                 </div>
             </div>
         </div>

--- a/app/src/routes/talks/-components/talks-year-group.tsx
+++ b/app/src/routes/talks/-components/talks-year-group.tsx
@@ -59,7 +59,7 @@ export default function TalksYearGroup({ year, slides, countLabel }: TalksYearGr
             </div>
             <div className={styles.body}>
                 {slides.map((slide, index) => (
-                    <SlideCard key={slide.id} slide={slide} index={index} priority={index === 0} />
+                    <SlideCard key={slide.id} slide={slide} index={index} />
                 ))}
             </div>
         </section>

--- a/app/src/routes/talks/-functions/get-slides.ts
+++ b/app/src/routes/talks/-functions/get-slides.ts
@@ -15,6 +15,11 @@ type SlideInfoV2 = {
     lastUpdated: string;
     type: "draft" | "public" | "private";
     tags: string[];
+    pictures?: Array<{
+        path: string;
+        blurhash?: string;
+        blur?: string;
+    }>;
     sourcePath: string;
 };
 
@@ -34,19 +39,26 @@ export const getSlides = createServerFn({ method: "GET" }).handler(async () => {
         .filter((v) => v.type !== "private")
         .sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime())
         .sort((a, b) => new Date(b.presentation?.date ?? "").getTime() - new Date(a.presentation?.date ?? "").getTime())
-        .map<Slide>((v) => ({
-            id: v.id,
-            title: v.title,
-            // R2の最初のページ画像をサムネイルとして利用する
-            image: `/slide/${v.id}/picture/1.png`,
-            // サムネ・タイトルは常にアプリ内の Slide ビューワへ
-            slideUrl: `/slide/${v.id}`,
-            // 発表イベント名の行だけ外部 URL（イベントページ等）
-            presentationUrl: v.presentation?.url,
-            lastUpdate: v.lastUpdated,
-            presentationDate: v.presentation?.date,
-            presentationName: v.presentation?.name,
-            tags: v.tags ?? [],
-            type: v.type,
-        }));
+        .map<Slide>((v) => {
+            const thumbnail = v.pictures?.[0];
+
+            return {
+                id: v.id,
+                title: v.title,
+                // 新しい slide-info は pictures 配列を持つので、その先頭をサムネイルに使う。
+                thumbnailImage: thumbnail ? `/slide/${v.id}/${thumbnail.path}` : undefined,
+                // 一部データの揺れも吸収できるよう blur もフォールバックで読む。
+                thumbnailBlurhash: thumbnail?.blurhash ?? thumbnail?.blur,
+                pageCount: v.pictures?.length ?? 0,
+                // サムネ・タイトルは常にアプリ内の Slide ビューワへ
+                slideUrl: `/slide/${v.id}`,
+                // 発表イベント名の行だけ外部 URL（イベントページ等）
+                presentationUrl: v.presentation?.url,
+                lastUpdate: v.lastUpdated,
+                presentationDate: v.presentation?.date,
+                presentationName: v.presentation?.name,
+                tags: v.tags ?? [],
+                type: v.type,
+            };
+        });
 });

--- a/app/src/routes/talks/-types/slide.ts
+++ b/app/src/routes/talks/-types/slide.ts
@@ -1,7 +1,9 @@
 export interface Slide {
     id: string;
     title: string;
-    image: string;
+    thumbnailImage: string | undefined;
+    thumbnailBlurhash: string | undefined;
+    pageCount: number;
     /** アプリ内の Slide 閲覧 URL（`/slide/:id`） */
     slideUrl: string;
     /** 発表イベント・イベントページ等の URL（メタデータに含まれる場合のみ） */

--- a/app/src/routes/talks/index.tsx
+++ b/app/src/routes/talks/index.tsx
@@ -87,7 +87,7 @@ const talksPageStyles = sva({
             display: "flex",
             alignItems: "center",
             gap: "3",
-            w: { base: "52", md: "72" },
+            w: { base: "48", md: "72" },
             h: "9",
             pl: "3",
             pr: "2",

--- a/storybook/stories/talks/slide-card.stories.tsx
+++ b/storybook/stories/talks/slide-card.stories.tsx
@@ -22,7 +22,6 @@ const meta: Meta<typeof SlideCard> = {
     args: {
         slide: talksStorySlides[0],
         index: 0,
-        priority: true,
     },
 };
 
@@ -36,6 +35,5 @@ export const WithoutPresentationLink: Story = {
     args: {
         slide: talksStorySlides[2],
         index: 2,
-        priority: false,
     },
 };

--- a/storybook/stories/talks/talks-story-data.ts
+++ b/storybook/stories/talks/talks-story-data.ts
@@ -4,7 +4,9 @@ export const talksStorySlides: Slide[] = [
     {
         id: "typescript-never",
         title: "Demystifying the never Type in TypeScript",
-        image: "https://picsum.photos/seed/typescript-never/960/540",
+        thumbnailImage: "https://picsum.photos/seed/typescript-never/960/540",
+        thumbnailBlurhash: "mGSY{r%KD%?b~p9Gk8ayt7xtofWB_4xtRkoyt5D*oeof~qxtM|ay",
+        pageCount: 11,
         slideUrl: "/slide/typescript-never",
         presentationUrl: "https://2024.tskaigi.org/talks/nikomaru",
         lastUpdate: "2024-05-15",
@@ -16,7 +18,9 @@ export const talksStorySlides: Slide[] = [
     {
         id: "react-server-components",
         title: "Designing Boundaries for React Server Components",
-        image: "https://picsum.photos/seed/react-server-components/960/540",
+        thumbnailImage: "https://picsum.photos/seed/react-server-components/960/540",
+        thumbnailBlurhash: "mLSPX_t7M{-;?bRjRjay-;j[WBWB_3WBWBWBofj[WBay~qj[ayof",
+        pageCount: 24,
         slideUrl: "/slide/react-server-components",
         presentationUrl: "https://example.com/react-server-components",
         lastUpdate: "2024-10-02",
@@ -28,7 +32,9 @@ export const talksStorySlides: Slide[] = [
     {
         id: "testing-ui-motion",
         title: "Testing Motion-heavy UI without Losing Confidence",
-        image: "https://picsum.photos/seed/testing-ui-motion/960/540",
+        thumbnailImage: "https://picsum.photos/seed/testing-ui-motion/960/540",
+        thumbnailBlurhash: "mWQT4Mt7xu%M?bRjj[of%MRjj[of~qWBRjt7%MWBWBof4nRjxua|",
+        pageCount: 8,
         slideUrl: "/slide/testing-ui-motion",
         presentationUrl: undefined,
         lastUpdate: "2025-02-19",


### PR DESCRIPTION
## What changed
- updated talks slide metadata parsing to use the new `pictures` array shape
- switched slide card thumbnails to read the first picture path and use blurhash as the placeholder background
- changed the slide card meta label from tags to page counts like `11P`
- refreshed the Storybook slide fixtures to match the new slide shape
- kept the current talks search width adjustment in scope

## Why
The slide metadata format changed from a single thumbnail field to a `pictures` array with blurhash data. The talks page still expected the old shape, so thumbnails and metadata labels needed to be updated to render correctly.

## Impact
- the talks archive now shows the correct thumbnail source for each slide
- users see page counts instead of tag labels in the thumbnail meta area
- slide cards render a blurhash-based placeholder before the thumbnail image is visible

## Validation
- `pnpm run check`
- verified `http://127.0.0.1:3000/talks` with Playwright and confirmed page-count labels plus blurhash-backed thumbnails
