### PR TITLE
🧪 Add tests for talks and slide helper logic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Check
         run: pnpm run check
 
+      - name: Test
+        run: pnpm run test
+
   deploy-app:
     needs: check
     env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Check
         run: pnpm run check
 
+      - name: Test
+        run: pnpm run test
+
   deploy-app-preview:
     needs: check
     env:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,27 +36,12 @@ jobs:
         shell: bash
         run: |
           set +e
-          pnpm run test 2>&1 | tee test-result.log
-          status=${PIPESTATUS[0]}
-
-          {
-            echo "<details>"
-            echo "<summary>Test Result</summary>"
-            echo
-
-            if [ "$status" -eq 0 ]; then
-              echo "✅ \`pnpm run test\` passed."
-            else
-              echo "❌ \`pnpm run test\` failed."
-            fi
-
-            echo
-            echo '```text'
-            cat test-result.log
-            echo '```'
-            echo
-            echo "</details>"
-          } > test-result.md
+          (
+            cd app
+            pnpm exec vitest run --config vitest.config.ts --reporter=json --outputFile=../test-result.json
+          )
+          status=$?
+          node .github/workflows/scripts/test-result-summarize.mjs test-result.json test-result.md "$status"
 
           exit "$status"
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -33,7 +33,40 @@ jobs:
         run: pnpm run check
 
       - name: Test
-        run: pnpm run test
+        shell: bash
+        run: |
+          set +e
+          pnpm run test 2>&1 | tee test-result.log
+          status=${PIPESTATUS[0]}
+
+          {
+            echo "<details>"
+            echo "<summary>Test Result</summary>"
+            echo
+
+            if [ "$status" -eq 0 ]; then
+              echo "✅ \`pnpm run test\` passed."
+            else
+              echo "❌ \`pnpm run test\` failed."
+            fi
+
+            echo
+            echo '```text'
+            cat test-result.log
+            echo '```'
+            echo
+            echo "</details>"
+          } > test-result.md
+
+          exit "$status"
+
+      - name: Upload test result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-result
+          path: test-result.md
+          if-no-files-found: ignore
 
   deploy-app-preview:
     needs: check
@@ -263,16 +296,25 @@ jobs:
           path: lighthouse-summary.md
 
   comment:
-    needs: [deploy-app-preview, deploy-storybook-preview, lighthouse-summary]
+    needs: [check, deploy-app-preview, deploy-storybook-preview, lighthouse-summary]
+    if: always()
     runs-on: ubuntu-latest
     name: Comment Preview URLs
     steps:
       - uses: actions/checkout@v4
 
       - name: Download Lighthouse summary
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: lighthouse-summary
+          path: .
+
+      - name: Download test result
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: test-result
           path: .
 
       - name: Create comment file
@@ -282,12 +324,37 @@ jobs:
         run: |
           cat << EOF > comment.md
           ## Deploy preview
-          - App Preview URL: $APP_PREVIEW_URL
-          - Storybook Preview URL: $STORYBOOK_PREVIEW_URL
           EOF
+
+          if [ -n "$APP_PREVIEW_URL" ]; then
+            echo "- App Preview URL: $APP_PREVIEW_URL" >> comment.md
+          else
+            echo "- App Preview URL: Not available" >> comment.md
+          fi
+
+          if [ -n "$STORYBOOK_PREVIEW_URL" ]; then
+            echo "- Storybook Preview URL: $STORYBOOK_PREVIEW_URL" >> comment.md
+          else
+            echo "- Storybook Preview URL: Not available" >> comment.md
+          fi
+
+          echo >> comment.md
 
           if [ -f lighthouse-summary.md ]; then
             cat lighthouse-summary.md >> comment.md
+          fi
+
+          if [ -f test-result.md ]; then
+            cat test-result.md >> comment.md
+          else
+            cat << EOF >> comment.md
+          <details>
+          <summary>Test Result</summary>
+
+          Test result artifact was not generated.
+
+          </details>
+          EOF
           fi
 
       - name: Create PR comment

--- a/.github/workflows/scripts/lighthouse-summarize.mjs
+++ b/.github/workflows/scripts/lighthouse-summarize.mjs
@@ -35,7 +35,18 @@ const logContents = (() => {
 })();
 
 if (!logContents.trim()) {
-    writeFileSync("lighthouse-summary.md", "No Lighthouse reports were generated.\n");
+    writeFileSync(
+        "lighthouse-summary.md",
+        [
+            "<details>",
+            "<summary>Lighthouse Summary</summary>",
+            "",
+            "No Lighthouse reports were generated.",
+            "",
+            "</details>",
+            "",
+        ].join("\n"),
+    );
     writeFileSync("lighthouse-failed.txt", "1\n");
     process.exit(0);
 }
@@ -175,6 +186,9 @@ const rows = urls
     .sort((a, b) => a.path.localeCompare(b.path));
 
 const lines = [];
+lines.push("<details>");
+lines.push("<summary>Lighthouse Summary</summary>");
+lines.push("");
 lines.push("## Lighthouse results");
 lines.push("");
 lines.push("| Path | Performance | Accessibility | Best Practices | SEO | Report |");
@@ -211,6 +225,9 @@ if (skipped) {
     lines.push("```");
     lines.push("");
 }
+
+lines.push("</details>");
+lines.push("");
 
 writeFileSync("lighthouse-summary.md", lines.join("\n"));
 writeFileSync("lighthouse-failed.txt", "0\n");

--- a/.github/workflows/scripts/test-result-summarize.mjs
+++ b/.github/workflows/scripts/test-result-summarize.mjs
@@ -1,0 +1,125 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { relative } from "node:path";
+
+const [, , inputPath = "test-result.json", outputPath = "test-result.md", exitStatus = "1"] = process.argv;
+
+function escapeTableCell(value) {
+    return String(value).replaceAll("\\", "\\\\").replaceAll("|", "\\|").replaceAll("\n", "<br>");
+}
+
+function formatDuration(startTime, endTime) {
+    if (typeof startTime !== "number" || typeof endTime !== "number") {
+        return "N/A";
+    }
+
+    const durationMs = Math.max(0, endTime - startTime);
+    if (durationMs < 1000) {
+        return `${Math.round(durationMs)}ms`;
+    }
+
+    return `${(durationMs / 1000).toFixed(2)}s`;
+}
+
+function formatStatus(status) {
+    if (status === "passed") return "✅ Passed";
+    if (status === "failed") return "❌ Failed";
+    if (status === "skipped" || status === "pending") return "⏭️ Skipped";
+    return escapeTableCell(status || "Unknown");
+}
+
+function getRelativeFileName(fileName) {
+    if (!fileName) return "N/A";
+
+    const relativePath = relative(process.cwd(), fileName);
+    return relativePath.startsWith("..") ? fileName : relativePath;
+}
+
+function countAssertions(assertionResults, status) {
+    return assertionResults.filter((assertion) => assertion.status === status).length;
+}
+
+function buildMissingResultSummary() {
+    const statusText = exitStatus === "0" ? "passed" : "failed";
+
+    return [
+        "<details>",
+        "<summary>Test Result</summary>",
+        "",
+        `\`pnpm run test\` ${statusText}, but Vitest JSON output was not generated.`,
+        "",
+        "</details>",
+        "",
+    ].join("\n");
+}
+
+if (!existsSync(inputPath)) {
+    writeFileSync(outputPath, buildMissingResultSummary());
+    process.exit(0);
+}
+
+const result = JSON.parse(readFileSync(inputPath, "utf8"));
+const statusLabel = result.success ? "✅ Passed" : "❌ Failed";
+const testResults = Array.isArray(result.testResults) ? result.testResults : [];
+const passedFiles = testResults.filter((testFile) => testFile.status === "passed").length;
+const failedFiles = testResults.filter((testFile) => testFile.status === "failed").length;
+const skippedFiles = testResults.filter(
+    (testFile) => testFile.status === "skipped" || testFile.status === "pending",
+).length;
+const lines = [];
+
+lines.push("<details>");
+lines.push("<summary>Test Result</summary>");
+lines.push("");
+lines.push(`## ${statusLabel}`);
+lines.push("");
+lines.push(
+    `Test files: ${passedFiles} passed / ${failedFiles} failed / ${skippedFiles} skipped / ${testResults.length} total`,
+);
+lines.push(
+    `Tests: ${result.numPassedTests ?? 0} passed / ${result.numFailedTests ?? 0} failed / ${result.numPendingTests ?? 0} skipped / ${result.numTotalTests ?? 0} total`,
+);
+lines.push("");
+lines.push("| Status | File | Passed | Failed | Skipped | Duration |");
+lines.push("| --- | --- | ---: | ---: | ---: | ---: |");
+
+for (const testFile of testResults) {
+    const assertions = Array.isArray(testFile.assertionResults) ? testFile.assertionResults : [];
+    const skipped = countAssertions(assertions, "pending") + countAssertions(assertions, "skipped");
+
+    lines.push(
+        `| ${formatStatus(testFile.status)} | ${escapeTableCell(getRelativeFileName(testFile.name))} | ${countAssertions(assertions, "passed")} | ${countAssertions(assertions, "failed")} | ${skipped} | ${formatDuration(testFile.startTime, testFile.endTime)} |`,
+    );
+}
+
+const failedAssertions = testResults.flatMap((testFile) => {
+    const fileName = getRelativeFileName(testFile.name);
+    const assertions = Array.isArray(testFile.assertionResults) ? testFile.assertionResults : [];
+
+    return assertions
+        .filter((assertion) => assertion.status === "failed")
+        .map((assertion) => ({
+            fileName,
+            fullName: assertion.fullName || assertion.title || "Unknown test",
+            message: (assertion.failureMessages || []).join("\n").slice(0, 1000),
+        }));
+});
+
+if (failedAssertions.length > 0) {
+    lines.push("");
+    lines.push("### Failed tests");
+    lines.push("");
+    lines.push("| File | Test | Message |");
+    lines.push("| --- | --- | --- |");
+
+    for (const failure of failedAssertions) {
+        lines.push(
+            `| ${escapeTableCell(failure.fileName)} | ${escapeTableCell(failure.fullName)} | ${escapeTableCell(failure.message || "N/A")} |`,
+        );
+    }
+}
+
+lines.push("");
+lines.push("</details>");
+lines.push("");
+
+writeFileSync(outputPath, lines.join("\n"));

--- a/app/package.json
+++ b/app/package.json
@@ -10,7 +10,7 @@
         "panda:codegen": "panda codegen",
         "paraglide:compile": "paraglide-js compile --project ./project.inlang --outdir ./src/paraglide",
         "preview": "pnpm run build && vite preview",
-        "test": "vitest run",
+        "test": "vitest run --config vitest.config.ts",
         "deploy": "pnpm run build && wrangler deploy",
         "cf-typegen": "wrangler types"
     },

--- a/app/src/routes/slide/$.tsx
+++ b/app/src/routes/slide/$.tsx
@@ -1,31 +1,8 @@
 import { env } from "cloudflare:workers";
 import { createFileRoute } from "@tanstack/react-router";
+import { isSlideTopHtmlResponse, isStaticAsset, resolveSlideR2Url } from "./-functions/slide-route-helper";
 
 const STATIC_CACHE_CONTROL = "public, max-age=86400, s-maxage=604800";
-
-function resolveR2Url(splat: string, segments: string[]): string {
-    // /slide/:id → :id/index.html
-    if (segments.length === 1) {
-        if (segments[0].endsWith("slidev-exported.pdf")) {
-            return `${env.R2_PUBLIC_URL}${segments[0].replace("slidev-exported.pdf", "/slidev-exported.pdf")}`;
-        }
-        return `${env.R2_PUBLIC_URL}${splat}/index.html`;
-    }
-    // /slide/:id/:pageNum → :id/index.html（SPA内ページ遷移）
-    if (segments.length === 2 && !Number.isNaN(Number(segments[1]))) {
-        return `${env.R2_PUBLIC_URL}${segments[0]}/index.html`;
-    }
-    return `${env.R2_PUBLIC_URL}${splat}`;
-}
-
-function isStaticAsset(contentType: string): boolean {
-    return (
-        contentType.startsWith("image/") ||
-        contentType.includes("css") ||
-        contentType.includes("javascript") ||
-        contentType.includes("font")
-    );
-}
 
 // HTML属性に安全に埋め込むためのエスケープ処理。
 // OGP用のmetaタグはユーザーが共有するURLに直接出るため、念のため最低限のサニタイズを行う。
@@ -113,18 +90,14 @@ export const Route = createFileRoute("/slide/$")({
                 headers.append("CF-Access-Client-Id", env.CF_ACCESS_CLIENT_ID);
                 headers.append("CF-Access-Client-Secret", env.CF_ACCESS_CLIENT_SECRET);
 
-                const slideUrl = resolveR2Url(splat, segments);
+                const slideUrl = resolveSlideR2Url(env.R2_PUBLIC_URL, splat, segments);
                 const res = await fetch(slideUrl, { headers });
 
                 const contentType = res.headers.get("content-type") || "";
 
                 // スライドのトップ HTML (`/slide/:id` または `/slide/:id/:pageNum`) には OGP メタを注入する。
                 // SNS でシェアされた際に Slidev のページ画像をサムネイルとして表示させるための処置。
-                const isSlideTopHtml =
-                    contentType.includes("text/html") &&
-                    res.ok &&
-                    (segments.length === 1 || (segments.length === 2 && !Number.isNaN(Number(segments[1]))));
-                if (isSlideTopHtml) {
+                if (isSlideTopHtmlResponse(contentType, res.ok, segments)) {
                     const slideTitle = await fetchSlideTitle(segments[0], headers);
                     return injectSlideOgpMeta(res, request.url, segments[0], slideTitle);
                 }

--- a/app/src/routes/slide/-functions/slide-route-helper.test.ts
+++ b/app/src/routes/slide/-functions/slide-route-helper.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { isSlideTopHtmlResponse, isStaticAsset, resolveSlideR2Url } from "./slide-route-helper";
+
+const r2PublicUrl = "https://r2.example.com/";
+
+describe("resolveSlideR2Url", () => {
+    it("resolves a slide top path to its index html", () => {
+        expect(resolveSlideR2Url(r2PublicUrl, "introducing-react", ["introducing-react"])).toBe(
+            "https://r2.example.com/introducing-react/index.html",
+        );
+    });
+
+    it("resolves numeric slide page paths to the slide index html", () => {
+        expect(resolveSlideR2Url(r2PublicUrl, "introducing-react/12", ["introducing-react", "12"])).toBe(
+            "https://r2.example.com/introducing-react/index.html",
+        );
+    });
+
+    it("passes static asset paths through to R2", () => {
+        expect(
+            resolveSlideR2Url(r2PublicUrl, "introducing-react/assets/style.css", [
+                "introducing-react",
+                "assets",
+                "style.css",
+            ]),
+        ).toBe("https://r2.example.com/introducing-react/assets/style.css");
+    });
+
+    it("resolves exported pdf paths to the pdf inside the slide directory", () => {
+        expect(
+            resolveSlideR2Url(r2PublicUrl, "introducing-react-slidev-exported.pdf", [
+                "introducing-react-slidev-exported.pdf",
+            ]),
+        ).toBe("https://r2.example.com/introducing-react-/slidev-exported.pdf");
+    });
+});
+
+describe("isStaticAsset", () => {
+    it.each([
+        "image/png",
+        "text/css; charset=utf-8",
+        "application/javascript",
+        "font/woff2",
+    ])("detects %s as a static asset", (contentType) => {
+        expect(isStaticAsset(contentType)).toBe(true);
+    });
+
+    it.each(["text/html", "application/json", "text/plain"])("does not detect %s as a static asset", (contentType) => {
+        expect(isStaticAsset(contentType)).toBe(false);
+    });
+});
+
+describe("isSlideTopHtmlResponse", () => {
+    it("detects top html for slide root and numeric page paths", () => {
+        expect(isSlideTopHtmlResponse("text/html", true, ["introducing-react"])).toBe(true);
+        expect(isSlideTopHtmlResponse("text/html; charset=utf-8", true, ["introducing-react", "12"])).toBe(true);
+    });
+
+    it("rejects non-html, failed, and asset paths", () => {
+        expect(isSlideTopHtmlResponse("application/javascript", true, ["introducing-react"])).toBe(false);
+        expect(isSlideTopHtmlResponse("text/html", false, ["introducing-react"])).toBe(false);
+        expect(isSlideTopHtmlResponse("text/html", true, ["introducing-react", "assets", "style.css"])).toBe(false);
+    });
+});

--- a/app/src/routes/slide/-functions/slide-route-helper.ts
+++ b/app/src/routes/slide/-functions/slide-route-helper.ts
@@ -1,0 +1,33 @@
+export function resolveSlideR2Url(r2PublicUrl: string, splat: string, segments: string[]): string {
+    // /slide/:id → :id/index.html
+    if (segments.length === 1) {
+        if (segments[0].endsWith("slidev-exported.pdf")) {
+            return `${r2PublicUrl}${segments[0].replace("slidev-exported.pdf", "/slidev-exported.pdf")}`;
+        }
+        return `${r2PublicUrl}${splat}/index.html`;
+    }
+
+    // /slide/:id/:pageNum → :id/index.html（SPA内ページ遷移）
+    if (isSlidePagePath(segments)) {
+        return `${r2PublicUrl}${segments[0]}/index.html`;
+    }
+
+    return `${r2PublicUrl}${splat}`;
+}
+
+export function isStaticAsset(contentType: string): boolean {
+    return (
+        contentType.startsWith("image/") ||
+        contentType.includes("css") ||
+        contentType.includes("javascript") ||
+        contentType.includes("font")
+    );
+}
+
+export function isSlideTopHtmlResponse(contentType: string, responseOk: boolean, segments: string[]): boolean {
+    return contentType.includes("text/html") && responseOk && (segments.length === 1 || isSlidePagePath(segments));
+}
+
+function isSlidePagePath(segments: string[]): boolean {
+    return segments.length === 2 && !Number.isNaN(Number(segments[1]));
+}

--- a/app/src/routes/talks/-functions/get-slides.ts
+++ b/app/src/routes/talks/-functions/get-slides.ts
@@ -1,27 +1,6 @@
 import { env } from "cloudflare:workers";
 import { createServerFn } from "@tanstack/react-start";
-import type { Slide } from "../-types/slide";
-
-type SlideInfoV2 = {
-    $schema: string;
-    id: string;
-    title: string;
-    created: string;
-    presentation: null | {
-        date: string;
-        name: string;
-        url: string;
-    };
-    lastUpdated: string;
-    type: "draft" | "public" | "private";
-    tags: string[];
-    pictures?: Array<{
-        path: string;
-        blurhash?: string;
-        blur?: string;
-    }>;
-    sourcePath: string;
-};
+import { type SlideInfoV2, toSlides } from "./slide-info";
 
 // R2からスライド一覧のメタデータのみを取得（画像はプロキシURL経由でブラウザが直接読み込む）
 export const getSlides = createServerFn({ method: "GET" }).handler(async () => {
@@ -35,30 +14,5 @@ export const getSlides = createServerFn({ method: "GET" }).handler(async () => {
 
     const data = (await res.json()) as SlideInfoV2[];
 
-    return data
-        .filter((v) => v.type !== "private")
-        .sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime())
-        .sort((a, b) => new Date(b.presentation?.date ?? "").getTime() - new Date(a.presentation?.date ?? "").getTime())
-        .map<Slide>((v) => {
-            const thumbnail = v.pictures?.[0];
-
-            return {
-                id: v.id,
-                title: v.title,
-                // 新しい slide-info は pictures 配列を持つので、その先頭をサムネイルに使う。
-                thumbnailImage: thumbnail ? `/slide/${v.id}/${thumbnail.path}` : undefined,
-                // 一部データの揺れも吸収できるよう blur もフォールバックで読む。
-                thumbnailBlurhash: thumbnail?.blurhash ?? thumbnail?.blur,
-                pageCount: v.pictures?.length ?? 0,
-                // サムネ・タイトルは常にアプリ内の Slide ビューワへ
-                slideUrl: `/slide/${v.id}`,
-                // 発表イベント名の行だけ外部 URL（イベントページ等）
-                presentationUrl: v.presentation?.url,
-                lastUpdate: v.lastUpdated,
-                presentationDate: v.presentation?.date,
-                presentationName: v.presentation?.name,
-                tags: v.tags ?? [],
-                type: v.type,
-            };
-        });
+    return toSlides(data);
 });

--- a/app/src/routes/talks/-functions/slide-info.test.ts
+++ b/app/src/routes/talks/-functions/slide-info.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import { type SlideInfoV2, toSlides } from "./slide-info";
+
+const baseSlideInfo = {
+    $schema: "https://example.com/schema.json",
+    created: "2026-01-01",
+    sourcePath: "slides/example.md",
+    tags: ["react"],
+} satisfies Pick<SlideInfoV2, "$schema" | "created" | "sourcePath" | "tags">;
+
+describe("toSlides", () => {
+    it("filters private slides and maps public metadata to slide cards", () => {
+        const slides = toSlides([
+            createSlideInfo({
+                id: "public-slide",
+                title: "Public Slide",
+                type: "public",
+                presentation: {
+                    date: "2026-02-01",
+                    name: "Frontend Meetup",
+                    url: "https://example.com/events/frontend-meetup",
+                },
+                pictures: [
+                    {
+                        path: "picture/1.png",
+                        blurhash: "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
+                        blur: "legacy-blur",
+                    },
+                    {
+                        path: "picture/2.png",
+                    },
+                ],
+            }),
+            createSlideInfo({
+                id: "private-slide",
+                title: "Private Slide",
+                type: "private",
+            }),
+        ]);
+
+        expect(slides).toEqual([
+            {
+                id: "public-slide",
+                title: "Public Slide",
+                thumbnailImage: "/slide/public-slide/picture/1.png",
+                thumbnailBlurhash: "LEHV6nWB2yk8pyo0adR*.7kCMdnj",
+                pageCount: 2,
+                slideUrl: "/slide/public-slide",
+                presentationUrl: "https://example.com/events/frontend-meetup",
+                lastUpdate: "2026-01-01",
+                presentationDate: "2026-02-01",
+                presentationName: "Frontend Meetup",
+                tags: ["react"],
+                type: "public",
+            },
+        ]);
+    });
+
+    it("uses legacy blur fallback and empty thumbnail values when pictures are missing", () => {
+        const slides = toSlides([
+            createSlideInfo({
+                id: "legacy-blur-slide",
+                title: "Legacy Blur Slide",
+                pictures: [
+                    {
+                        path: "picture/1.png",
+                        blur: "legacy-blur",
+                    },
+                ],
+            }),
+            createSlideInfo({
+                id: "no-picture-slide",
+                title: "No Picture Slide",
+                pictures: undefined,
+            }),
+        ]);
+
+        expect(slides).toMatchObject([
+            {
+                id: "legacy-blur-slide",
+                thumbnailImage: "/slide/legacy-blur-slide/picture/1.png",
+                thumbnailBlurhash: "legacy-blur",
+                pageCount: 1,
+            },
+            {
+                id: "no-picture-slide",
+                thumbnailImage: undefined,
+                thumbnailBlurhash: undefined,
+                pageCount: 0,
+            },
+        ]);
+    });
+
+    it("orders by presentation date when both slides have one and otherwise keeps last update ordering", () => {
+        const slides = toSlides([
+            createSlideInfo({
+                id: "older-presentation",
+                title: "Older Presentation",
+                lastUpdated: "2026-01-20",
+                presentation: {
+                    date: "2026-03-01",
+                    name: "Older Event",
+                    url: "https://example.com/events/older",
+                },
+            }),
+            createSlideInfo({
+                id: "newer-draft",
+                title: "Newer Draft",
+                lastUpdated: "2026-04-01",
+                type: "draft",
+                presentation: null,
+            }),
+            createSlideInfo({
+                id: "newer-presentation",
+                title: "Newer Presentation",
+                lastUpdated: "2026-01-10",
+                presentation: {
+                    date: "2026-04-01",
+                    name: "Newer Event",
+                    url: "https://example.com/events/newer",
+                },
+            }),
+            createSlideInfo({
+                id: "older-draft",
+                title: "Older Draft",
+                lastUpdated: "2026-03-01",
+                type: "draft",
+                presentation: null,
+            }),
+        ]);
+
+        expect(slides.map((slide) => slide.id)).toEqual([
+            "newer-draft",
+            "older-draft",
+            "newer-presentation",
+            "older-presentation",
+        ]);
+    });
+});
+
+function createSlideInfo(overrides: Partial<SlideInfoV2>): SlideInfoV2 {
+    return {
+        ...baseSlideInfo,
+        id: "slide",
+        title: "Slide",
+        lastUpdated: "2026-01-01",
+        type: "public",
+        presentation: null,
+        pictures: [],
+        ...overrides,
+    };
+}

--- a/app/src/routes/talks/-functions/slide-info.ts
+++ b/app/src/routes/talks/-functions/slide-info.ts
@@ -1,0 +1,53 @@
+import type { Slide } from "../-types/slide";
+
+export type SlideInfoV2 = {
+    $schema: string;
+    id: string;
+    title: string;
+    created: string;
+    presentation: null | {
+        date: string;
+        name: string;
+        url: string;
+    };
+    lastUpdated: string;
+    type: "draft" | "public" | "private";
+    tags: string[];
+    pictures?: Array<{
+        path: string;
+        blurhash?: string;
+        blur?: string;
+    }>;
+    sourcePath: string;
+};
+
+export function toSlides(slideInfoList: SlideInfoV2[]): Slide[] {
+    return slideInfoList
+        .filter((slideInfo) => slideInfo.type !== "private")
+        .sort((a, b) => new Date(b.lastUpdated).getTime() - new Date(a.lastUpdated).getTime())
+        .sort((a, b) => new Date(b.presentation?.date ?? "").getTime() - new Date(a.presentation?.date ?? "").getTime())
+        .map((slideInfo) => toSlide(slideInfo));
+}
+
+function toSlide(slideInfo: SlideInfoV2): Slide {
+    const thumbnail = slideInfo.pictures?.[0];
+
+    return {
+        id: slideInfo.id,
+        title: slideInfo.title,
+        // 新しい slide-info は pictures 配列を持つので、その先頭をサムネイルに使う。
+        thumbnailImage: thumbnail ? `/slide/${slideInfo.id}/${thumbnail.path}` : undefined,
+        // 一部データの揺れも吸収できるよう blur もフォールバックで読む。
+        thumbnailBlurhash: thumbnail?.blurhash ?? thumbnail?.blur,
+        pageCount: slideInfo.pictures?.length ?? 0,
+        // サムネ・タイトルは常にアプリ内の Slide ビューワへ
+        slideUrl: `/slide/${slideInfo.id}`,
+        // 発表イベント名の行だけ外部 URL（イベントページ等）
+        presentationUrl: slideInfo.presentation?.url,
+        lastUpdate: slideInfo.lastUpdated,
+        presentationDate: slideInfo.presentation?.date,
+        presentationName: slideInfo.presentation?.name,
+        tags: slideInfo.tags ?? [],
+        type: slideInfo.type,
+    };
+}

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath, URL } from "node:url";
+import viteReact from "@vitejs/plugin-react";
+import viteTsConfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    resolve: {
+        alias: {
+            "@": fileURLToPath(new URL("./src", import.meta.url)),
+        },
+    },
+    plugins: [
+        viteTsConfigPaths({
+            projects: ["./tsconfig.json"],
+        }),
+        viteReact(),
+    ],
+    test: {
+        environment: "node",
+        include: ["src/**/*.test.{ts,tsx}"],
+    },
+});


### PR DESCRIPTION
## Summary
- Add route-local unit tests for talks slide data transformation.
- Extract slide route URL/static/HTML helper logic and cover it with unit tests.
- Add a Vitest-specific config so unit tests do not load the Cloudflare Vite plugin.
- Run `pnpm run test` in the Preview and Deploy workflow check jobs so Actions shows the test result.

## Validation
- `pnpm run test`
- `pnpm run check`

Closes #26