### PR TITLE
[codex] Add responsive About page

### DIFF
--- a/app/src/components/site-footer.tsx
+++ b/app/src/components/site-footer.tsx
@@ -28,21 +28,45 @@ const siteFooterStyles = sva({
             gap: "2",
         },
         socialLink: {
+            "--social-color": "#ffffff",
             display: "inline-flex",
             alignItems: "center",
             justifyContent: "center",
             w: "12",
             h: "12",
             borderRadius: "md",
-            color: "fg.subtle",
-            transition: "color 0.2s ease, background-color 0.2s ease",
+            color: "var(--social-color)",
+            transition: "background-color 0.25s ease, transform 0.25s ease",
+            "&[data-brand='github']": {
+                "--social-color": "#8b5cf6",
+            },
+            "&[data-brand='instagram']": {
+                "--social-color": "#dd00ae",
+            },
+            "&[data-brand='x']": {
+                "--social-color": "#1d9bf0",
+            },
             _hover: {
-                bg: "bg.emphasized",
+                bg: "color-mix(in srgb, var(--social-color) 12%, transparent)",
+                transform: "translateY(-2px)",
+                "& [data-social-icon]": {
+                    transform: "scale(1.08)",
+                },
+            },
+            _focusVisible: {
+                outlineWidth: "2px",
+                outlineStyle: "solid",
+                outlineColor: "var(--social-color)",
+                outlineOffset: "2px",
             },
         },
         socialIcon: {
             w: "4",
             h: "4",
+            transition: "transform 0.25s ease",
+            "@media (prefers-reduced-motion: reduce)": {
+                transition: "none",
+            },
         },
         creditBlock: {
             display: "flex",
@@ -69,16 +93,19 @@ const socialLinks = [
     {
         href: "https://github.com/nlkomaru",
         label: "GitHub",
+        brand: "github",
         Icon: Github,
     },
     {
         href: "https://www.instagram.com/nikomaru0102/",
         label: "Instagram",
+        brand: "instagram",
         Icon: Instagram,
     },
     {
         href: "https://x.com/nikomaru0102",
         label: "X",
+        brand: "x",
         Icon: Twitter,
     },
 ] as const;
@@ -115,16 +142,17 @@ export function SiteFooter() {
                     </p>
                 </div>
                 <div className={styles.social}>
-                    {socialLinks.map(({ href, label, Icon }) => (
+                    {socialLinks.map(({ href, label, brand, Icon }) => (
                         <a
                             key={href}
                             href={href}
                             className={styles.socialLink}
+                            data-brand={brand}
                             target="_blank"
                             rel="noopener noreferrer"
                             aria-label={label}
                         >
-                            <Icon className={styles.socialIcon} aria-hidden="true" />
+                            <Icon className={styles.socialIcon} data-social-icon aria-hidden="true" />
                         </a>
                     ))}
                 </div>

--- a/app/src/routes/(site)/_main/about/-components/about-introduction.tsx
+++ b/app/src/routes/(site)/_main/about/-components/about-introduction.tsx
@@ -1,0 +1,137 @@
+import { Blocks, PanelsTopLeft, Waypoints } from "lucide-react";
+import { motion } from "motion/react";
+import { sva } from "styled-system/css";
+
+const aboutIntroductionStyles = sva({
+    slots: [
+        "root",
+        "content",
+        "summary",
+        "title",
+        "highlights",
+        "highlight",
+        "icon",
+        "highlightText",
+        "copy",
+        "paragraph",
+    ],
+    base: {
+        root: {
+            display: "flex",
+            flexDirection: "column",
+            gap: { base: "6", md: "10" },
+        },
+        content: {
+            display: "grid",
+            gridTemplateColumns: { base: "minmax(0, 1fr)", lg: "minmax(20rem, 0.8fr) minmax(0, 1.2fr)" },
+            gap: { base: "8", lg: "16" },
+            alignItems: "start",
+        },
+        summary: {
+            display: "flex",
+            flexDirection: "column",
+            gap: { base: "7", md: "9" },
+        },
+        title: {
+            maxW: "2xl",
+            color: "fg.subtle",
+            fontFamily: "heading",
+            fontSize: { base: "3xl", md: "4xl", xl: "5xl" },
+            fontWeight: "semibold",
+            letterSpacing: "-0.035em",
+            lineHeight: { base: "1.25", md: "1.18" },
+        },
+        highlights: {
+            display: "flex",
+            flexDirection: "column",
+            borderBlockWidth: "1px",
+            borderColor: "border.default",
+        },
+        highlight: {
+            display: "grid",
+            gridTemplateColumns: "2rem minmax(0, 1fr)",
+            gap: "3",
+            alignItems: "center",
+            py: "3.5",
+            borderBottomWidth: "1px",
+            borderColor: "border.default",
+            _last: {
+                borderBottomWidth: "0",
+            },
+        },
+        icon: {
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            color: "fg.muted",
+            "& svg": {
+                boxSize: "4",
+                strokeWidth: "1.5",
+            },
+        },
+        highlightText: {
+            color: "fg",
+            fontSize: { base: "sm", md: "md" },
+            lineHeight: "1.6",
+        },
+        copy: {
+            display: "flex",
+            flexDirection: "column",
+            gap: { base: "4", md: "5" },
+            pt: { lg: "1" },
+        },
+        paragraph: {
+            color: "fg",
+            fontSize: { base: "sm", md: "md" },
+            lineHeight: { base: "1.85", md: "1.9" },
+        },
+    },
+});
+
+interface AboutIntroductionProps {
+    title: string;
+    paragraphs: string[];
+    highlights: string[];
+}
+
+const highlightIcons = [Blocks, Waypoints, PanelsTopLeft];
+
+export default function AboutIntroduction({ title, paragraphs, highlights }: AboutIntroductionProps) {
+    const styles = aboutIntroductionStyles();
+
+    return (
+        <motion.header
+            className={styles.root}
+            initial={{ opacity: 0, y: 16 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.45, ease: "easeOut" }}
+        >
+            <div className={styles.content}>
+                <div className={styles.summary}>
+                    <h1 className={styles.title}>{title}</h1>
+                    <ul className={styles.highlights}>
+                        {highlights.map((highlight, index) => {
+                            const Icon = highlightIcons[index % highlightIcons.length];
+
+                            return (
+                                <li key={highlight} className={styles.highlight}>
+                                    <span className={styles.icon} aria-hidden>
+                                        <Icon />
+                                    </span>
+                                    <span className={styles.highlightText}>{highlight}</span>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+                <div className={styles.copy}>
+                    {paragraphs.map((paragraph) => (
+                        <p key={paragraph} className={styles.paragraph}>
+                            {paragraph}
+                        </p>
+                    ))}
+                </div>
+            </div>
+        </motion.header>
+    );
+}

--- a/app/src/routes/(site)/_main/about/-components/career-timeline.tsx
+++ b/app/src/routes/(site)/_main/about/-components/career-timeline.tsx
@@ -1,0 +1,182 @@
+import { sva } from "styled-system/css";
+import type { Locale } from "../../../../../paraglide/runtime";
+import { formatAboutPeriod } from "../-functions/format-about-date";
+import type { LocalizedCareer } from "../-types/about";
+
+const careerTimelineStyles = sva({
+    slots: [
+        "root",
+        "header",
+        "eyebrow",
+        "title",
+        "description",
+        "list",
+        "item",
+        "period",
+        "marker",
+        "indicator",
+        "content",
+        "number",
+        "itemTitle",
+        "itemDescription",
+    ],
+    base: {
+        root: {
+            display: "flex",
+            flexDirection: "column",
+            gap: "8",
+        },
+        header: {
+            display: "flex",
+            flexDirection: "column",
+            gap: "4",
+        },
+        eyebrow: {
+            color: "fg.muted",
+            fontFamily: "mono",
+            fontSize: "2xs",
+            letterSpacing: "0.3em",
+            textTransform: "uppercase",
+        },
+        title: {
+            color: "fg.subtle",
+            fontFamily: "heading",
+            fontSize: { base: "3xl", md: "5xl" },
+            fontWeight: "semibold",
+            letterSpacing: "-0.025em",
+            lineHeight: "1.2",
+        },
+        description: {
+            color: "fg.muted",
+            fontSize: { base: "sm", md: "md" },
+            lineHeight: "1.9",
+        },
+        list: {
+            display: "flex",
+            flexDirection: "column",
+        },
+        item: {
+            display: "grid",
+            gridTemplateColumns: { base: "0.75rem minmax(0, 1fr)", md: "12rem 2rem minmax(0, 1fr)" },
+            gridTemplateAreas: {
+                base: '"marker period" "marker content"',
+                md: '"period marker content"',
+            },
+            columnGap: { base: "2", md: "5" },
+        },
+        period: {
+            gridArea: "period",
+            pt: { base: "0", md: "1.5" },
+            pb: { base: "1.5", md: "0" },
+            color: "fg.muted",
+            fontFamily: "mono",
+            fontSize: { base: "sm", md: "xs" },
+            letterSpacing: { base: "0.04em", md: "0.08em" },
+            lineHeight: "1.65",
+            textAlign: { base: "left", md: "right" },
+            textTransform: "uppercase",
+        },
+        marker: {
+            gridArea: "marker",
+            position: "relative",
+            display: "flex",
+            justifyContent: "center",
+            _after: {
+                content: '""',
+                position: "absolute",
+                insetBlockStart: "3",
+                insetBlockEnd: "0",
+                w: "1px",
+                bg: "border.default",
+            },
+        },
+        indicator: {
+            position: "relative",
+            zIndex: "base",
+            boxSize: "2.5",
+            mt: "2",
+            borderWidth: "1px",
+            borderColor: "fg.subtle",
+            borderRadius: "full",
+            bg: "bg.canvas",
+        },
+        content: {
+            gridArea: "content",
+            minW: 0,
+            display: "flex",
+            flexDirection: "column",
+            gap: "1.5",
+            pt: "2",
+            pb: { base: "7", md: "6" },
+            borderBottomWidth: {
+                base: "none",
+                md: "1px",
+            },
+            borderColor: "border.default",
+        },
+        number: {
+            color: "fg.muted/70",
+            fontFamily: "mono",
+            fontSize: "2xs",
+            display: {
+                base: "none",
+                md: "inline-block",
+            },
+            letterSpacing: "0.1em",
+        },
+        itemTitle: {
+            color: "fg.subtle",
+            fontSize: { base: "md", md: "lg" },
+            fontWeight: "medium",
+            letterSpacing: "-0.015em",
+            lineHeight: "1.4",
+        },
+        itemDescription: {
+            color: "fg.muted",
+            fontSize: { base: "xs", md: "sm" },
+            lineHeight: "1.8",
+        },
+    },
+});
+
+interface CareerTimelineProps {
+    title: string;
+    description: string;
+    presentLabel: string;
+    locale: Locale;
+    items: LocalizedCareer[];
+}
+
+export default function CareerTimeline({ title, description, presentLabel, locale, items }: CareerTimelineProps) {
+    const styles = careerTimelineStyles();
+
+    return (
+        <section className={styles.root} aria-labelledby="career-heading">
+            <header className={styles.header}>
+                <p className={styles.eyebrow}>— Career</p>
+                <h2 id="career-heading" className={styles.title}>
+                    {title}
+                </h2>
+                <p className={styles.description}>{description}</p>
+            </header>
+
+            <ol className={styles.list}>
+                {items.map((item, index) => (
+                    <li key={item.id} className={styles.item}>
+                        <time className={styles.period}>
+                            {formatAboutPeriod(item.startDate, item.endDate, locale, presentLabel)}
+                        </time>
+                        <div className={styles.marker} aria-hidden>
+                            <span className={styles.indicator} />
+                        </div>
+                        <article className={styles.content}>
+                            <span className={styles.number}>{String(index + 1).padStart(2, "0")}</span>
+                            <h3 className={styles.itemTitle}>{item.title}</h3>
+                            <p className={styles.itemDescription}>{item.description}</p>
+                        </article>
+                    </li>
+                ))}
+            </ol>
+        </section>
+    );
+}

--- a/app/src/routes/(site)/_main/about/-components/qualification-list.tsx
+++ b/app/src/routes/(site)/_main/about/-components/qualification-list.tsx
@@ -1,0 +1,160 @@
+import { sva } from "styled-system/css";
+import type { Locale } from "../../../../../paraglide/runtime";
+import { formatAboutDate } from "../-functions/format-about-date";
+import type { LocalizedQualification } from "../-types/about";
+
+const qualificationListStyles = sva({
+    slots: [
+        "root",
+        "header",
+        "eyebrow",
+        "title",
+        "description",
+        "list",
+        "item",
+        "number",
+        "date",
+        "content",
+        "name",
+        "issuer",
+        "empty",
+    ],
+    base: {
+        root: {
+            display: "flex",
+            flexDirection: "column",
+            gap: { base: "10", md: "12" },
+        },
+        header: {
+            display: "flex",
+            flexDirection: "column",
+            gap: "4",
+            pt: { md: "8" },
+        },
+        eyebrow: {
+            color: "fg.muted",
+            fontFamily: "mono",
+            fontSize: "2xs",
+            letterSpacing: "0.3em",
+            textTransform: "uppercase",
+        },
+        title: {
+            color: "fg.subtle",
+            fontFamily: "heading",
+            fontSize: { base: "3xl", md: "5xl" },
+            fontWeight: "semibold",
+            letterSpacing: "-0.025em",
+            lineHeight: "1.2",
+        },
+        description: {
+            maxW: "2xl",
+            color: "fg.muted",
+            fontSize: "sm",
+            lineHeight: "1.8",
+        },
+        list: {
+            display: "flex",
+            flexDirection: "column",
+            borderBottomWidth: "1px",
+            borderColor: "border.default",
+        },
+        item: {
+            display: "grid",
+            gridTemplateColumns: {
+                base: "4rem minmax(0, 1fr)",
+                md: "6rem 12rem minmax(0, 1fr)",
+            },
+            columnGap: { base: "3", md: "6" },
+            rowGap: { base: "1", md: "0" },
+            alignItems: "center",
+            py: { base: "5", md: "4" },
+            borderTopWidth: "1px",
+            borderColor: "border.default",
+        },
+        number: {
+            color: "fg.muted/70",
+            fontFamily: "mono",
+            fontSize: { base: "sm", md: "sm" },
+            fontWeight: "medium",
+            letterSpacing: "0.1em",
+            alignSelf: { base: "start", md: "center" },
+            lineHeight: "1.6",
+        },
+        date: {
+            color: "fg.muted",
+            fontFamily: "mono",
+            fontSize: { base: "sm", md: "sm" },
+            letterSpacing: "0.04em",
+            lineHeight: "1.6",
+            textTransform: "uppercase",
+            gridColumn: { base: "2", md: "auto" },
+        },
+        content: {
+            minW: 0,
+            display: "flex",
+            flexDirection: "column",
+            gap: "1",
+            gridColumn: { base: "2", md: "auto" },
+        },
+        name: {
+            color: "fg.subtle",
+            fontSize: { base: "md", md: "lg" },
+            fontWeight: "medium",
+            letterSpacing: "-0.015em",
+            lineHeight: "1.5",
+        },
+        issuer: {
+            color: "fg.muted",
+            fontSize: { base: "xs", md: "sm" },
+            lineHeight: "1.6",
+        },
+        empty: {
+            borderBlockWidth: "1px",
+            borderColor: "border.default",
+            py: "8",
+            color: "fg.muted",
+            fontSize: "sm",
+        },
+    },
+});
+
+interface QualificationListProps {
+    title: string;
+    description: string;
+    emptyLabel: string;
+    locale: Locale;
+    items: LocalizedQualification[];
+}
+
+export default function QualificationList({ title, description, emptyLabel, locale, items }: QualificationListProps) {
+    const styles = qualificationListStyles();
+
+    return (
+        <section className={styles.root} aria-labelledby="qualification-heading">
+            <header className={styles.header}>
+                <p className={styles.eyebrow}>— Certifications</p>
+                <h2 id="qualification-heading" className={styles.title}>
+                    {title}
+                </h2>
+                <p className={styles.description}>{description}</p>
+            </header>
+
+            {items.length === 0 ? (
+                <p className={styles.empty}>{emptyLabel}</p>
+            ) : (
+                <ol className={styles.list}>
+                    {items.map((item, index) => (
+                        <li key={item.id} className={styles.item}>
+                            <span className={styles.number}>{String(index + 1).padStart(2, "0")}</span>
+                            <time className={styles.date}>{formatAboutDate(item.acquiredAt, locale)}</time>
+                            <div className={styles.content}>
+                                <h3 className={styles.name}>{item.name}</h3>
+                                <p className={styles.issuer}>{item.issuer}</p>
+                            </div>
+                        </li>
+                    ))}
+                </ol>
+            )}
+        </section>
+    );
+}

--- a/app/src/routes/(site)/_main/about/-data/about-data.json
+++ b/app/src/routes/(site)/_main/about/-data/about-data.json
@@ -1,0 +1,46 @@
+{
+    "profile": {
+        "en": {
+            "pageTitle": "About",
+            "metaDescription": "About Nikomaru, a computer science student and software developer working across web applications and Minecraft server technology.",
+            "title": "I turn ideas into software that works in practice.",
+            "paragraphs": [
+                "I'm Nikomaru, a fourth-year Computer Science student in the Faculty of Engineering at Shinshu University. I build Minecraft plugins with Kotlin and web applications with TypeScript and React.",
+                "At Morino Party, I work across the systems that connect the game server and the web. This includes authentication and APIs built with Hono and Cloudflare Workers, as well as user-facing applications built with TanStack Start.",
+                "I also maintain development and delivery workflows with Docker and GitHub Actions. My goal is to build software that remains understandable for maintainers and straightforward for the people using it."
+            ],
+            "highlights": [
+                "Minecraft plugins that support community gameplay",
+                "Authentication and APIs connecting game and web",
+                "Web interfaces designed for continued operation"
+            ],
+            "careerTitle": "Career & learning",
+            "careerDescription": "My education and community involvement.",
+            "qualificationTitle": "Qualifications & certifications",
+            "qualificationDescription": "Certifications and examinations I have completed.",
+            "qualificationEmptyLabel": "Qualification details are being prepared.",
+            "presentLabel": "Present"
+        },
+        "ja": {
+            "pageTitle": "私について",
+            "metaDescription": "信州大学でコンピュータサイエンスを学びながら、WebアプリケーションとMinecraftサーバー周辺の開発に取り組むNikomaruのプロフィール。",
+            "title": "アイデアを、実際に使えるソフトウェアにする。",
+            "paragraphs": [
+                "Nikomaruです。信州大学工学部でコンピュータサイエンスを学びながら、KotlinによるMinecraftプラグイン開発と、TypeScript・ReactによるWebアプリケーション開発に取り組んでいます。",
+                "「もりのパーティ」では、ゲームサーバーとWebをつなぐ仕組みを担当しています。HonoやCloudflare Workersを使った認証・APIから、TanStack Startを使ったユーザー向け画面まで、必要な範囲を横断して設計・実装しています。",
+                "DockerやGitHub Actionsを使った開発・運用環境も含め、公開後に保守しやすく、利用者にとって迷いにくいソフトウェアを作ることを大切にしています。"
+            ],
+            "highlights": [
+                "コミュニティを支えるMinecraftプラグイン",
+                "ゲームとWebをつなぐ認証・API",
+                "継続運用を見据えたWebインターフェース"
+            ],
+            "careerTitle": "経歴と学び",
+            "careerDescription": "学歴とコミュニティでの活動歴です。",
+            "qualificationTitle": "資格・認定",
+            "qualificationDescription": "取得した資格と合格した試験です。",
+            "qualificationEmptyLabel": "資格情報は準備中です。",
+            "presentLabel": "現在"
+        }
+    }
+}

--- a/app/src/routes/(site)/_main/about/-data/careers.json
+++ b/app/src/routes/(site)/_main/about/-data/careers.json
@@ -1,0 +1,41 @@
+[
+    {
+        "id": "shinshu-university",
+        "startDate": "2023-04",
+        "endDate": null,
+        "title": {
+            "en": "Shinshu University, Department of Electrical and Computer Engineering",
+            "ja": "信州大学 工学部 電子情報システム工学科 在学中"
+        },
+        "description": {
+            "en": "Studying computer science and engineering, with graduation expected in March 2027.",
+            "ja": "コンピュータサイエンスと心理学、教育学など幅広い分野を学んでいます。2027年3月卒業予定です。"
+        }
+    },
+    {
+        "id": "morino-party",
+        "startDate": "2021-12",
+        "endDate": null,
+        "title": {
+            "en": "Morino Party, Software Developer",
+            "ja": "もりのパーティ ソフトウェア開発"
+        },
+        "description": {
+            "en": "Developing and operating Minecraft plugins, web applications, APIs, and shared design systems for the community.",
+            "ja": "コミュニティ向けのMinecraftプラグイン、Webアプリケーション、API、共通デザインシステムを開発・運用しています。"
+        }
+    },
+    {
+        "id": "aichi-prefectural-aichi-high-school-of-technology-and-engineering",
+        "startDate": "2020-04",
+        "endDate": "2023-03",
+        "title": {
+            "en": "Graduated from Aichi Prefectural Aichi High School of Technology and Engineering",
+            "ja": "愛知県立愛知総合工科高等学校 卒業"
+        },
+        "description": {
+            "en": "Completed upper secondary education in March 2023.",
+            "ja": "工業高校出身で、情報技術及び、電気電子について学んでいました。2023年3月に卒業しました。"
+        }
+    }
+]

--- a/app/src/routes/(site)/_main/about/-data/qualifications.json
+++ b/app/src/routes/(site)/_main/about/-data/qualifications.json
@@ -31,7 +31,7 @@
             "ja": "応用情報技術者試験"
         },
         "issuer": {
-            "en": "Information-technology Promotion Agency, Japan (IPA)",
+            "en": "Innovation Platform Agency, Japan (IPA)",
             "ja": "情報処理推進機構（IPA）"
         }
     },
@@ -43,7 +43,7 @@
             "ja": "基本情報技術者試験"
         },
         "issuer": {
-            "en": "Information-technology Promotion Agency, Japan (IPA)",
+            "en": "Innovation Platform Agency, Japan (IPA)",
             "ja": "情報処理推進機構（IPA）"
         }
     },

--- a/app/src/routes/(site)/_main/about/-data/qualifications.json
+++ b/app/src/routes/(site)/_main/about/-data/qualifications.json
@@ -1,0 +1,62 @@
+[
+    {
+        "id": "toeic-listening-and-reading-715",
+        "acquiredAt": "2026-06-02",
+        "name": {
+            "en": "TOEIC Listening & Reading 715",
+            "ja": "TOEIC L&R 715"
+        },
+        "issuer": {
+            "en": "The Institute for International Business Communication (IIBC)",
+            "ja": "国際ビジネスコミュニケーション協会（IIBC）"
+        }
+    },
+    {
+        "id": "test-of-world-heritage-study-2nd-grade",
+        "acquiredAt": "2026-03-13",
+        "name": {
+            "en": "World Heritage Test, Level 2",
+            "ja": "世界遺産検定 2級"
+        },
+        "issuer": {
+            "en": "The World Heritage Academy",
+            "ja": "世界遺産アカデミー"
+        }
+    },
+    {
+        "id": "applied-information-technology-engineer-examination",
+        "acquiredAt": "2023-06-29",
+        "name": {
+            "en": "Applied Information Technology Engineer Examination",
+            "ja": "応用情報技術者試験"
+        },
+        "issuer": {
+            "en": "Information-technology Promotion Agency, Japan (IPA)",
+            "ja": "情報処理推進機構（IPA）"
+        }
+    },
+    {
+        "id": "fundamental-information-technology-engineer-examination",
+        "acquiredAt": "2022-06-27",
+        "name": {
+            "en": "Fundamental Information Technology Engineer Examination",
+            "ja": "基本情報技術者試験"
+        },
+        "issuer": {
+            "en": "Information-technology Promotion Agency, Japan (IPA)",
+            "ja": "情報処理推進機構（IPA）"
+        }
+    },
+    {
+        "id": "test-of-world-heritage-study-3rd-grade",
+        "acquiredAt": "2019-07-01",
+        "name": {
+            "en": "World Heritage Test, Level 3",
+            "ja": "世界遺産検定 3級"
+        },
+        "issuer": {
+            "en": "The World Heritage Academy",
+            "ja": "世界遺産アカデミー"
+        }
+    }
+]

--- a/app/src/routes/(site)/_main/about/-functions/format-about-date.test.ts
+++ b/app/src/routes/(site)/_main/about/-functions/format-about-date.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { formatAboutDate, formatAboutPeriod } from "./format-about-date";
+
+describe("formatAboutDate", () => {
+    it("formats a year-month value for Japanese", () => {
+        expect(formatAboutDate("2023-04", "ja")).toBe("2023年4月");
+    });
+
+    it("formats a year-month value for English", () => {
+        expect(formatAboutDate("2023-04", "en")).toBe("Apr 2023");
+    });
+
+    it("keeps the acquisition day when it is available", () => {
+        expect(formatAboutDate("2023-06-29", "ja")).toBe("2023年6月29日");
+    });
+});
+
+describe("formatAboutPeriod", () => {
+    it("uses a single date for a point-in-time event", () => {
+        expect(formatAboutPeriod("2023-03", "2023-03", "ja", "現在")).toBe("2023年3月");
+    });
+
+    it("uses the provided present label for an ongoing period", () => {
+        expect(formatAboutPeriod("2023-04", null, "en", "Present")).toBe("Apr 2023 — Present");
+    });
+});

--- a/app/src/routes/(site)/_main/about/-functions/format-about-date.ts
+++ b/app/src/routes/(site)/_main/about/-functions/format-about-date.ts
@@ -1,0 +1,40 @@
+import type { Locale } from "../../../../../paraglide/runtime";
+
+function parseAboutDate(value: string): { date: Date; hasDay: boolean } {
+    const [year, month, day] = value.split("-").map(Number);
+
+    if (!year || !month || month < 1 || month > 12 || (day !== undefined && (day < 1 || day > 31))) {
+        throw new Error(`Invalid date value: ${value}`);
+    }
+
+    return {
+        date: new Date(Date.UTC(year, month - 1, day ?? 1)),
+        hasDay: day !== undefined,
+    };
+}
+
+export function formatAboutDate(value: string, locale: Locale): string {
+    const { date, hasDay } = parseAboutDate(value);
+
+    return new Intl.DateTimeFormat(locale, {
+        year: "numeric",
+        month: "short",
+        day: hasDay ? "numeric" : undefined,
+        timeZone: "UTC",
+    }).format(date);
+}
+
+export function formatAboutPeriod(
+    startDate: string,
+    endDate: string | null,
+    locale: Locale,
+    presentLabel: string,
+): string {
+    const start = formatAboutDate(startDate, locale);
+
+    if (endDate === startDate) {
+        return start;
+    }
+
+    return `${start} — ${endDate ? formatAboutDate(endDate, locale) : presentLabel}`;
+}

--- a/app/src/routes/(site)/_main/about/-types/about.ts
+++ b/app/src/routes/(site)/_main/about/-types/about.ts
@@ -1,0 +1,46 @@
+import type { Locale } from "../../../../../paraglide/runtime";
+
+export type LocalizedText = Record<Locale, string>;
+
+export interface AboutProfile {
+    pageTitle: string;
+    metaDescription: string;
+    title: string;
+    paragraphs: string[];
+    highlights: string[];
+    careerTitle: string;
+    careerDescription: string;
+    qualificationTitle: string;
+    qualificationDescription: string;
+    qualificationEmptyLabel: string;
+    presentLabel: string;
+}
+
+export interface Career {
+    id: string;
+    startDate: string;
+    endDate: string | null;
+    title: LocalizedText;
+    description: LocalizedText;
+}
+
+export interface LocalizedCareer extends Omit<Career, "title" | "description"> {
+    title: string;
+    description: string;
+}
+
+export interface Qualification {
+    id: string;
+    acquiredAt: string;
+    name: LocalizedText;
+    issuer: LocalizedText;
+}
+
+export interface LocalizedQualification extends Omit<Qualification, "name" | "issuer"> {
+    name: string;
+    issuer: string;
+}
+
+export interface AboutData {
+    profile: Record<Locale, AboutProfile>;
+}

--- a/app/src/routes/(site)/_main/about/index.tsx
+++ b/app/src/routes/(site)/_main/about/index.tsx
@@ -1,157 +1,105 @@
 import { createFileRoute } from "@tanstack/react-router";
-import { motion } from "motion/react";
 import { sva } from "styled-system/css";
+import { getLocale } from "../../../../paraglide/runtime";
+import AboutIntroduction from "./-components/about-introduction";
+import CareerTimeline from "./-components/career-timeline";
+import QualificationList from "./-components/qualification-list";
+import aboutData from "./-data/about-data.json";
+import careersData from "./-data/careers.json";
+import qualificationsData from "./-data/qualifications.json";
+import type { AboutData, Career, LocalizedText, Qualification } from "./-types/about";
 
 const aboutPageStyles = sva({
-    slots: [
-        "root",
-        "eyebrow",
-        "grid",
-        "profileColumn",
-        "profileCard",
-        "profileName",
-        "profileSummary",
-        "copyColumn",
-        "title",
-        "titleAccent",
-        "description",
-        "skills",
-        "skillPill",
-    ],
+    slots: ["root", "container", "details"],
     base: {
         root: {
+            w: "full",
             minH: { base: "calc(100dvh - 3.5rem)", md: "100dvh" },
+            flexGrow: 1,
             bg: "bg.canvas",
-            px: { base: "8", md: "20" },
-            pt: { base: "24", md: "28" },
-            pb: "20",
         },
-        eyebrow: {
-            mb: "4",
-            fontSize: "0.625rem",
-            textTransform: "uppercase",
-            letterSpacing: "0.45em",
-            color: "fg.muted",
-        },
-        grid: {
-            display: "grid",
-            gap: "10",
-            gridTemplateColumns: { md: "repeat(12, minmax(0, 1fr))" },
-        },
-        profileColumn: {
-            gridColumn: { md: "span 5 / span 5" },
-        },
-        profileCard: {
-            aspectRatio: "3 / 4",
-            borderWidth: "1px",
-            borderColor: "border.default",
-            bg: "bg",
-            p: "6",
-            boxShadow: "sm",
-        },
-        profileName: {
-            fontSize: "xs",
-            textTransform: "uppercase",
-            letterSpacing: "0.3em",
-            color: "fg.muted",
-        },
-        profileSummary: {
-            mt: "4",
-            fontSize: "sm",
-            lineHeight: "7",
-            color: "fg.subtle",
-        },
-        copyColumn: {
-            gridColumn: { md: "span 7 / span 7" },
-        },
-        title: {
-            fontSize: { base: "2rem", md: "3.5rem" },
-            lineHeight: 1.1,
-        },
-        titleAccent: {
-            fontStyle: "italic",
-        },
-        description: {
-            mt: "8",
-            maxW: "2xl",
-            fontSize: "sm",
-            lineHeight: "8",
-            color: "fg.subtle",
-        },
-        skills: {
-            mt: "10",
+        container: {
             display: "flex",
-            flexWrap: "wrap",
-            gap: "3",
+            flexDirection: "column",
+            gap: { base: "20", md: "28" },
+            px: { base: "4", md: "12" },
+            py: { base: "12", md: "20" },
         },
-        skillPill: {
-            borderWidth: "1px",
-            borderColor: "border.default",
-            bg: "bg",
-            px: "4",
-            py: "2",
-            fontSize: "xs",
-            textTransform: "uppercase",
-            letterSpacing: "0.25em",
-            color: "fg.subtle",
+        details: {
+            display: "flex",
+            flexDirection: "column",
+            gap: { base: "20", md: "24" },
         },
     },
 });
 
+const data = aboutData as AboutData;
+const careers = careersData as Career[];
+const qualifications = qualificationsData as Qualification[];
+
 export const Route = createFileRoute("/(site)/_main/about/")({
+    head: () => {
+        const locale = getLocale();
+        const profile = data.profile[locale];
+
+        return {
+            meta: [
+                {
+                    title: `${profile.pageTitle} | Nikomaru Portfolio`,
+                },
+                {
+                    name: "description",
+                    content: profile.metaDescription,
+                },
+            ],
+        };
+    },
     component: AboutPage,
 });
 
+function localize(text: LocalizedText): string {
+    return text[getLocale()];
+}
+
 function AboutPage() {
     const styles = aboutPageStyles();
+    const locale = getLocale();
+    const profile = data.profile[locale];
 
     return (
-        <div className={styles.root}>
-            <motion.p initial={{ opacity: 0, y: 12 }} animate={{ opacity: 1, y: 0 }} className={styles.eyebrow}>
-                About
-            </motion.p>
+        <main className={styles.root}>
+            <div className={styles.container}>
+                <AboutIntroduction
+                    title={profile.title}
+                    paragraphs={profile.paragraphs}
+                    highlights={profile.highlights}
+                />
 
-            <section className={styles.grid}>
-                <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className={styles.profileColumn}>
-                    <div className={styles.profileCard}>
-                        <p className={styles.profileName}>Nikomaru</p>
-                        <p className={styles.profileSummary}>
-                            Web engineer focused on making polished products that are simple to maintain.
-                        </p>
-                    </div>
-                </motion.div>
-
-                <motion.div
-                    initial={{ opacity: 0, x: 20 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    className={styles.copyColumn}
-                >
-                    <h1 className={styles.title}>
-                        Design like an artist,
-                        <br />
-                        <span
-                            className={styles.titleAccent}
-                            style={{ color: "transparent", WebkitTextStroke: "1px rgba(31,41,55,0.45)" }}
-                        >
-                            ship like an engineer
-                        </span>
-                    </h1>
-                    <p className={styles.description}>
-                        I enjoy translating rough ideas into maintainable code. I care about visual quality, clean
-                        component boundaries, and pragmatic delivery speed.
-                    </p>
-
-                    <div className={styles.skills}>
-                        {["TypeScript", "React", "TanStack Start", "Cloudflare Workers", "Hono", "Storybook"].map(
-                            (skill) => (
-                                <span key={skill} className={styles.skillPill}>
-                                    {skill}
-                                </span>
-                            ),
-                        )}
-                    </div>
-                </motion.div>
-            </section>
-        </div>
+                <div className={styles.details}>
+                    <CareerTimeline
+                        title={profile.careerTitle}
+                        description={profile.careerDescription}
+                        presentLabel={profile.presentLabel}
+                        locale={locale}
+                        items={careers.map((career) => ({
+                            ...career,
+                            title: localize(career.title),
+                            description: localize(career.description),
+                        }))}
+                    />
+                    <QualificationList
+                        title={profile.qualificationTitle}
+                        description={profile.qualificationDescription}
+                        emptyLabel={profile.qualificationEmptyLabel}
+                        locale={locale}
+                        items={qualifications.map((qualification) => ({
+                            ...qualification,
+                            name: localize(qualification.name),
+                            issuer: localize(qualification.issuer),
+                        }))}
+                    />
+                </div>
+            </div>
+        </main>
     );
 }

--- a/app/src/routes/(site)/_main/talks/index.tsx
+++ b/app/src/routes/(site)/_main/talks/index.tsx
@@ -34,7 +34,7 @@ const talksPageStyles = sva({
         },
         container: {
             px: { base: "4", md: "12" },
-            pt: { base: "12", md: "20" },
+            py: { base: "12", md: "20" },
             display: "flex",
             flexDirection: "column",
             gap: { base: "14", md: "20" },
@@ -166,12 +166,12 @@ function SlidesPage() {
                         flexShrink={0}
                         maxW="100%"
                         startElement={<Search size={14} className={styles.searchIcon} aria-hidden />}
-                        w={{ base: "12rem", md: "18rem" }}
+                        w={{ base: "11rem", md: "18rem" }}
                     >
                         <Input
                             type="search"
                             variant="flushed"
-                            size="lg"
+                            size={{ base: "sm", md: "lg" }}
                             value={query}
                             onChange={(event) => setQuery(event.target.value)}
                             placeholder={m["talks.searchPlaceholder"]()}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -7,6 +7,7 @@
         "lib": ["ES2022", "DOM", "DOM.Iterable"],
         "types": ["./worker-configuration.d.ts", "node", "vite/client"],
         "moduleResolution": "bundler",
+        "resolveJsonModule": true,
         "allowImportingTsExtensions": true,
         "verbatimModuleSyntax": true,
         "noEmit": true,

--- a/storybook/stories/about/about-introduction.stories.tsx
+++ b/storybook/stories/about/about-introduction.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import AboutIntroduction from "@/routes/(site)/_main/about/-components/about-introduction";
+
+const meta: Meta<typeof AboutIntroduction> = {
+    title: "routes/(site)/_main/about/AboutIntroduction",
+    component: AboutIntroduction,
+    tags: ["autodocs"],
+    parameters: {
+        layout: "centered",
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 1200, minWidth: 1200, padding: 24 }}>
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        title: "I turn ideas into software that works in practice.",
+        paragraphs: [
+            "I'm Nikomaru, a computer science student and software developer.",
+            "I work across web applications, APIs, and Minecraft server technology.",
+        ],
+        highlights: [
+            "Minecraft plugins that support community gameplay",
+            "Authentication and APIs connecting game and web",
+            "Web interfaces designed for continued operation",
+        ],
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/storybook/stories/about/career-timeline.stories.tsx
+++ b/storybook/stories/about/career-timeline.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import CareerTimeline from "@/routes/(site)/_main/about/-components/career-timeline";
+
+const meta: Meta<typeof CareerTimeline> = {
+    title: "routes/(site)/_main/about/CareerTimeline",
+    component: CareerTimeline,
+    tags: ["autodocs"],
+    parameters: {
+        layout: "centered",
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 1044, minWidth: 1044, padding: 24 }}>
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        title: "Timeline",
+        description: "Education and community work shown by period.",
+        presentLabel: "Present",
+        locale: "en",
+        items: [
+            {
+                id: "university",
+                startDate: "2023-04",
+                endDate: null,
+                title: "Shinshu University, Bachelor of Engineering",
+                description: "Studying computer science in the Faculty of Engineering.",
+            },
+            {
+                id: "community",
+                startDate: "2023-04",
+                endDate: null,
+                title: "Morino Party, Software Developer",
+                description: "Developing web applications and Minecraft server technology.",
+            },
+        ],
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/storybook/stories/about/qualification-list.stories.tsx
+++ b/storybook/stories/about/qualification-list.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import QualificationList from "@/routes/(site)/_main/about/-components/qualification-list";
+
+const meta: Meta<typeof QualificationList> = {
+    title: "routes/(site)/_main/about/QualificationList",
+    component: QualificationList,
+    tags: ["autodocs"],
+    parameters: {
+        layout: "centered",
+    },
+    decorators: [
+        (Story) => (
+            <div style={{ width: 1044, minWidth: 1044, padding: 24 }}>
+                <Story />
+            </div>
+        ),
+    ],
+    args: {
+        title: "Qualifications",
+        description: "Certifications and licenses managed in JSON.",
+        emptyLabel: "Qualification details are being prepared.",
+        locale: "en",
+        items: [
+            {
+                id: "sample",
+                acquiredAt: "2025-04-15",
+                name: "Sample Certification",
+                issuer: "Sample Certification Organization",
+            },
+        ],
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Empty: Story = {
+    args: {
+        items: [],
+    },
+};


### PR DESCRIPTION
## Summary

- add a localized About introduction with icon-supported focus areas
- add responsive career timeline and qualification list components
- load career and qualification content from separate JSON files
- show qualification dates and issuing organizations
- add Storybook stories and date-formatting tests

## Why

The portfolio needs an About page that explains the work in prose while keeping career and qualification records structured and maintainable. The responsive layouts make the same information readable on desktop and mobile.

## Validation

- `pnpm run check`
- `pnpm test` (21 tests passed)
- Playwright screenshots at 1200px and 390px widths

Closes #46