### PR TITLE
Add www custom domain route

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,7 +66,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_KEY }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          environment: production
           command: deploy
           workingDirectory: app
           secrets: |

--- a/app/wrangler.jsonc
+++ b/app/wrangler.jsonc
@@ -16,6 +16,10 @@
         {
             "pattern": "nikomaru.dev",
             "custom_domain": true
+        },
+        {
+            "pattern": "www.nikomaru.dev",
+            "custom_domain": true
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Add `www.nikomaru.dev` as a Cloudflare custom domain route.
- Remove the explicit production environment input from the deploy workflow so deployment uses the app configuration directly.

## Validation

- `pnpm -w run check`
- pre-commit hook: `biome check . --write`